### PR TITLE
[Feat] #10 Calendar entry detail(날짜 상세 조회) API 구현

### DIFF
--- a/src/main/java/com/nova/yeobaek/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/controller/CalendarController.java
@@ -1,10 +1,16 @@
 package com.nova.yeobaek.domain.calendar.controller;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nova.yeobaek.domain.calendar.controller.docs.CalendarControllerDocs;
+import com.nova.yeobaek.domain.calendar.dto.response.CalendarResponseDTO;
 import com.nova.yeobaek.domain.calendar.service.CalendarService;
+import com.nova.yeobaek.domain.user.domain.User;
+import com.nova.yeobaek.global.payload.response.CommonResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,8 +18,17 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/calendars")
+@RequestMapping("/api/calendar") // ✅ /api/calendar/entries/{date}
 public class CalendarController implements CalendarControllerDocs {
 
 	private final CalendarService calendarService;
+
+	@Override
+	@GetMapping("/entries/{date}")
+	public CommonResponse<CalendarResponseDTO.EntryDetailResponse> getEntryDetail(
+			@AuthenticationPrincipal(expression = "user") User user,
+			@PathVariable String date
+	) {
+		return CommonResponse.onSuccess(calendarService.getEntryDetail(user.getId(), date));
+	}
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/controller/docs/CalendarControllerDocs.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/controller/docs/CalendarControllerDocs.java
@@ -1,7 +1,34 @@
 package com.nova.yeobaek.domain.calendar.controller.docs;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.nova.yeobaek.domain.calendar.dto.response.CalendarResponseDTO;
+import com.nova.yeobaek.domain.user.domain.User;
+import com.nova.yeobaek.global.payload.response.CommonResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Calendar", description = "달력 API")
 public interface CalendarControllerDocs {
+
+    @Operation(
+            summary = "날짜 상세 조회",
+            description = """
+					선택한 날짜의 OOTD 기록 상세를 조회합니다.
+					- CUSTOM 이미지가 존재하면 썸네일 타입은 CUSTOM
+					- CUSTOM이 없고 OOTD가 존재하면 썸네일 타입은 OOTD
+					- 기록이 없으면 200 + 빈 result 구조 반환
+					- date 형식이 틀리면 COMMON400
+					"""
+    )
+    CommonResponse<CalendarResponseDTO.EntryDetailResponse> getEntryDetail(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "user") User user,
+
+            @Parameter(description = "조회 날짜 (YYYY-MM-DD)", example = "2025-06-28")
+            @PathVariable("date") String date
+    );
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/converter/CalendarConverter.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/converter/CalendarConverter.java
@@ -1,4 +1,46 @@
 package com.nova.yeobaek.domain.calendar.converter;
 
+import org.springframework.stereotype.Component;
+
+import com.nova.yeobaek.domain.calendar.domain.Calendar;
+import com.nova.yeobaek.domain.calendar.dto.response.CalendarResponseDTO;
+import com.nova.yeobaek.domain.calendar.dto.response.CalendarResponseDTO.EntryDetailResponse;
+import com.nova.yeobaek.domain.calendar.dto.response.CalendarResponseDTO.EntryDetailResponse.OotdInfo;
+import com.nova.yeobaek.domain.calendar.domain.enums.Thumbnail;
+
+@Component
 public class CalendarConverter {
+
+    public EntryDetailResponse toEntryDetailResponse(Calendar calendar) {
+        Thumbnail thumbnail = null;
+        String thumbnailImageUrl = null;
+
+        // 1) CUSTOM 이미지가 있으면 CUSTOM 우선
+        if (calendar.getCustomImageUrl() != null && !calendar.getCustomImageUrl().isBlank()) {
+            thumbnail = Thumbnail.CUSTOM;
+            thumbnailImageUrl = calendar.getCustomImageUrl();
+        }
+        // 2) CUSTOM 없고 OOTD 있으면 OOTD
+        else if (calendar.getOotd() != null) {
+            thumbnail = Thumbnail.OOTD;
+            // Calendar 테이블에 ootdImageUrl이 필수로 있으니 그 값을 썸네일로 사용
+            thumbnailImageUrl = calendar.getOotdImageUrl();
+        }
+
+        OotdInfo ootdInfo = null;
+        if (calendar.getOotd() != null) {
+            ootdInfo = OotdInfo.builder()
+                    .ootdId(calendar.getOotd().getId())
+                    .ootdImageUrl(calendar.getOotdImageUrl())
+                    .build();
+        }
+
+        return CalendarResponseDTO.EntryDetailResponse.builder()
+                .date(calendar.getDate().toString())
+                .thumbnail(thumbnail)
+                .thumbnailImageUrl(thumbnailImageUrl)
+                .ootd(ootdInfo)
+                .customImageUrl(calendar.getCustomImageUrl())
+                .build();
+    }
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/dto/response/CalendarResponseDTO.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/dto/response/CalendarResponseDTO.java
@@ -1,4 +1,44 @@
 package com.nova.yeobaek.domain.calendar.dto.response;
 
+import com.nova.yeobaek.domain.calendar.domain.enums.Thumbnail;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class CalendarResponseDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EntryDetailResponse {
+
+        private String date;                 // YYYY-MM-DD
+        private Thumbnail thumbnail;         // CUSTOM / OOTD (없으면 null)
+        private String thumbnailImageUrl;    // 썸네일 이미지 URL (없으면 null)
+
+        private OotdInfo ootd;               // 없으면 null
+        private String customImageUrl;       // 없으면 null
+
+        @Getter
+        @Builder
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class OotdInfo {
+            private Long ootdId;
+            private String ootdImageUrl;
+        }
+
+        public static EntryDetailResponse empty(String date) {
+            return EntryDetailResponse.builder()
+                    .date(date)
+                    .thumbnail(null)
+                    .thumbnailImageUrl(null)
+                    .ootd(null)
+                    .customImageUrl(null)
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/repository/CalendarRepositoryCustom.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/repository/CalendarRepositoryCustom.java
@@ -1,4 +1,12 @@
 package com.nova.yeobaek.domain.calendar.repository;
 
+import java.time.LocalDate;
+import java.util.Optional;
+
+import com.nova.yeobaek.domain.calendar.domain.Calendar;
+
 public interface CalendarRepositoryCustom {
+
+    Optional<Calendar> findByUserIdAndDate(Long userId, LocalDate date);
 }
+

--- a/src/main/java/com/nova/yeobaek/domain/calendar/repository/CalendarRepositoryImpl.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/repository/CalendarRepositoryImpl.java
@@ -1,10 +1,32 @@
 package com.nova.yeobaek.domain.calendar.repository;
 
-import org.springframework.stereotype.Repository;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import com.nova.yeobaek.domain.calendar.domain.Calendar;
+import com.nova.yeobaek.domain.calendar.domain.QCalendar;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 
-@Repository
 @RequiredArgsConstructor
 public class CalendarRepositoryImpl implements CalendarRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Calendar> findByUserIdAndDate(Long userId, LocalDate date) {
+        QCalendar calendar = QCalendar.calendar;
+
+        Calendar result = queryFactory
+                .selectFrom(calendar)
+                .where(
+                        // ✅ 기존: calendar.userId.eq(userId)  (필드 없음)
+                        calendar.user.id.eq(userId),
+                        calendar.date.eq(date)
+                )
+                .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/service/CalendarService.java
@@ -1,7 +1,16 @@
 package com.nova.yeobaek.domain.calendar.service;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.nova.yeobaek.domain.calendar.converter.CalendarConverter;
+import com.nova.yeobaek.domain.calendar.dto.response.CalendarResponseDTO;
+import com.nova.yeobaek.domain.calendar.repository.CalendarRepository;
+import com.nova.yeobaek.global.payload.exception.GeneralException;
+import com.nova.yeobaek.global.payload.status.CommonErrorStatus;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,4 +20,21 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Transactional
 public class CalendarService {
+
+    private final CalendarRepository calendarRepository;
+    private final CalendarConverter calendarConverter;
+
+    @Transactional(readOnly = true)
+    public CalendarResponseDTO.EntryDetailResponse getEntryDetail(Long userId, String date) {
+        LocalDate parsedDate;
+        try {
+            parsedDate = LocalDate.parse(date); // YYYY-MM-DD
+        } catch (DateTimeParseException e) {
+            throw new GeneralException(CommonErrorStatus._BAD_REQUEST); // COMMON400
+        }
+
+        return calendarRepository.findByUserIdAndDate(userId, parsedDate)
+                .map(calendarConverter::toEntryDetailResponse)
+                .orElse(CalendarResponseDTO.EntryDetailResponse.empty(date));
+    }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate # Flyway가 DDL 담당 -> validate나 none으로 둬야 함
+      ddl-auto: update # Flyway가 DDL 담당 -> validate나 none으로 둬야 함
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
Resolves: #10

캘린더 날짜별 엔트리 상세 조회 API를 구현했습니다.  
사용자가 선택한 날짜(date)에 대해 해당 날짜의 캘린더 정보와
연결된 OOTD 요약 데이터를 함께 조회할 수 있도록 구성했습니다.

---

## 변경 사항
- 날짜별 캘린더 엔트리 상세 조회 API 구현
- CalendarController / CalendarService 로직 추가
- CalendarRepositoryCustom / Impl을 통한 커스텀 조회 로직 구현
- CalendarResponseDTO 및 Converter 매핑 처리

---

## 테스트
- [x] Swagger,Postman 기반 API 테스트 완료
- [x] local 환경(PostgreSQL)에서 날짜별 조회 정상 동작 확인
<img width="1356" height="863" alt="스크린샷 2026-01-12 102208" src="https://github.com/user-attachments/assets/514a4ca8-9947-4d85-9df5-f98422b0f399" />

---

## 참고 사항
- calendar 도메인 기준으로만 구현되었으며,  
  OOTD 도메인과의 연결은 조회(연결 정보 반환) 수준으로 처리했습니다.
- application-local.yml 수정 사항 포함

---

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [ ] 빌드/설정 변경
- [ ] 파일/폴더 구조 변경
- [ ] 파일/폴더 삭제

---

## PR Checklist
- [x] 커밋 메시지 컨벤션 준수
- [x] 변경 사항에 대한 테스트 완료 (Swagger 기준)

---

📣 To Reviewers
- 캘린더 날짜 상세 조회 흐름 및 DTO 설계 위주로 봐주시면 됩니다.
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #이슈 //이슈 번호는 추적을 위해 필요합니다!
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
