### PR TITLE
[Feat] #17 캘린더 날짜 조회/생성/삭제 및 커스텀·대표 이미지 API 구현

### DIFF
--- a/src/main/java/com/nova/yeobaek/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/controller/CalendarController.java
@@ -25,7 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/calendar")
+@RequestMapping("/api/calendars")
 @Validated
 public class CalendarController implements CalendarControllerDocs {
 
@@ -47,7 +47,8 @@ public class CalendarController implements CalendarControllerDocs {
 			@PathVariable String date,
 			@RequestBody @Valid CalendarRequestDTO.CreateEntryRequest request
 	) {
-		return CommonResponse.onSuccess(calendarService.createEntry(user.getId(), date, request.getOotdId()));
+		//  record accessor
+		return CommonResponse.onSuccess(calendarService.createEntry(user.getId(), date, request.ootdId()));
 	}
 
 	@Override
@@ -66,7 +67,8 @@ public class CalendarController implements CalendarControllerDocs {
 			@PathVariable String date,
 			@RequestBody @Valid CalendarRequestDTO.CustomImageRequest request
 	) {
-		return CommonResponse.onSuccess(calendarService.addCustomImage(user.getId(), date, request.getImageUrl()));
+		//  record accessor
+		return CommonResponse.onSuccess(calendarService.addCustomImage(user.getId(), date, request.imageUrl()));
 	}
 
 	@Override
@@ -85,6 +87,7 @@ public class CalendarController implements CalendarControllerDocs {
 			@PathVariable String date,
 			@RequestBody @Valid CalendarRequestDTO.UpdateThumbnailRequest request
 	) {
-		return CommonResponse.onSuccess(calendarService.updateThumbnail(user.getId(), date, request.getThumbnail()));
+		//  record accessor
+		return CommonResponse.onSuccess(calendarService.updateThumbnail(user.getId(), date, request.thumbnail()));
 	}
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/controller/CalendarController.java
@@ -1,17 +1,23 @@
 package com.nova.yeobaek.domain.calendar.controller;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nova.yeobaek.domain.calendar.controller.docs.CalendarControllerDocs;
+import com.nova.yeobaek.domain.calendar.dto.request.CalendarRequestDTO;
 import com.nova.yeobaek.domain.calendar.dto.response.CalendarResponseDTO;
 import com.nova.yeobaek.domain.calendar.service.CalendarService;
 import com.nova.yeobaek.domain.user.domain.User;
 import com.nova.yeobaek.global.payload.response.CommonResponse;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -19,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/calendar") // ✅ /api/calendar/entries/{date}
+@Validated
 public class CalendarController implements CalendarControllerDocs {
 
 	private final CalendarService calendarService;
@@ -30,5 +37,24 @@ public class CalendarController implements CalendarControllerDocs {
 			@PathVariable String date
 	) {
 		return CommonResponse.onSuccess(calendarService.getEntryDetail(user.getId(), date));
+	}
+
+	@Override
+	@PostMapping("/entries/{date}")
+	public CommonResponse<CalendarResponseDTO.EntryDetailResponse> connectOotd(
+			@AuthenticationPrincipal(expression = "user") User user,
+			@PathVariable String date,
+			@RequestBody @Valid CalendarRequestDTO.ConnectOotdRequest request
+	) {
+		return CommonResponse.onSuccess(calendarService.connectOotd(user.getId(), date, request.getOotdId()));
+	}
+
+	@Override
+	@DeleteMapping("/entries/{date}")
+	public CommonResponse<CalendarResponseDTO.EntryDeleteResponse> disconnectOotd(
+			@AuthenticationPrincipal(expression = "user") User user,
+			@PathVariable String date
+	) {
+		return CommonResponse.onSuccess(calendarService.disconnectOotd(user.getId(), date));
 	}
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/controller/CalendarController.java
@@ -1,10 +1,16 @@
 package com.nova.yeobaek.domain.calendar.controller;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nova.yeobaek.domain.calendar.controller.docs.CalendarControllerDocs;
+import com.nova.yeobaek.domain.calendar.dto.response.CalendarResponseDTO;
 import com.nova.yeobaek.domain.calendar.service.CalendarService;
+import com.nova.yeobaek.domain.user.domain.User;
+import com.nova.yeobaek.global.payload.response.CommonResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,8 +18,17 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/calendars")
+@RequestMapping("/api/calendar") // ✅ /api/calendar/entries/{date}
 public class CalendarController implements CalendarControllerDocs {
 
 	private final CalendarService calendarService;
+
+	@Override
+	@GetMapping("/entries/{date}")
+	public CommonResponse<CalendarResponseDTO.EntryDetailResponse> getEntryDetail(
+			@AuthenticationPrincipal(expression = "user") User user,
+			@PathVariable String date
+	) {
+		return CommonResponse.onSuccess(calendarService.getEntryDetail(user.getId(), date));
+	}
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/controller/CalendarController.java
@@ -4,6 +4,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,7 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/calendar") // ✅ /api/calendar/entries/{date}
+@RequestMapping("/api/calendar")
 @Validated
 public class CalendarController implements CalendarControllerDocs {
 
@@ -41,20 +42,49 @@ public class CalendarController implements CalendarControllerDocs {
 
 	@Override
 	@PostMapping("/entries/{date}")
-	public CommonResponse<CalendarResponseDTO.EntryDetailResponse> connectOotd(
+	public CommonResponse<CalendarResponseDTO.EntryDetailResponse> createEntry(
 			@AuthenticationPrincipal(expression = "user") User user,
 			@PathVariable String date,
-			@RequestBody @Valid CalendarRequestDTO.ConnectOotdRequest request
+			@RequestBody @Valid CalendarRequestDTO.CreateEntryRequest request
 	) {
-		return CommonResponse.onSuccess(calendarService.connectOotd(user.getId(), date, request.getOotdId()));
+		return CommonResponse.onSuccess(calendarService.createEntry(user.getId(), date, request.getOotdId()));
 	}
 
 	@Override
 	@DeleteMapping("/entries/{date}")
-	public CommonResponse<CalendarResponseDTO.EntryDeleteResponse> disconnectOotd(
+	public CommonResponse<CalendarResponseDTO.EntryDeleteResponse> deleteEntry(
 			@AuthenticationPrincipal(expression = "user") User user,
 			@PathVariable String date
 	) {
-		return CommonResponse.onSuccess(calendarService.disconnectOotd(user.getId(), date));
+		return CommonResponse.onSuccess(calendarService.deleteEntry(user.getId(), date));
+	}
+
+	@Override
+	@PostMapping("/entries/{date}/custom-image")
+	public CommonResponse<CalendarResponseDTO.EntryDetailResponse> addCustomImage(
+			@AuthenticationPrincipal(expression = "user") User user,
+			@PathVariable String date,
+			@RequestBody @Valid CalendarRequestDTO.CustomImageRequest request
+	) {
+		return CommonResponse.onSuccess(calendarService.addCustomImage(user.getId(), date, request.getImageUrl()));
+	}
+
+	@Override
+	@DeleteMapping("/entries/{date}/custom-image")
+	public CommonResponse<CalendarResponseDTO.EntryDetailResponse> deleteCustomImage(
+			@AuthenticationPrincipal(expression = "user") User user,
+			@PathVariable String date
+	) {
+		return CommonResponse.onSuccess(calendarService.deleteCustomImage(user.getId(), date));
+	}
+
+	@Override
+	@PatchMapping("/entries/{date}/thumbnail")
+	public CommonResponse<CalendarResponseDTO.EntryDetailResponse> updateThumbnail(
+			@AuthenticationPrincipal(expression = "user") User user,
+			@PathVariable String date,
+			@RequestBody @Valid CalendarRequestDTO.UpdateThumbnailRequest request
+	) {
+		return CommonResponse.onSuccess(calendarService.updateThumbnail(user.getId(), date, request.getThumbnail()));
 	}
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/controller/docs/CalendarControllerDocs.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/controller/docs/CalendarControllerDocs.java
@@ -2,7 +2,9 @@ package com.nova.yeobaek.domain.calendar.controller.docs;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
+import com.nova.yeobaek.domain.calendar.dto.request.CalendarRequestDTO;
 import com.nova.yeobaek.domain.calendar.dto.response.CalendarResponseDTO;
 import com.nova.yeobaek.domain.user.domain.User;
 import com.nova.yeobaek.global.payload.response.CommonResponse;
@@ -10,6 +12,7 @@ import com.nova.yeobaek.global.payload.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 
 @Tag(name = "Calendar", description = "달력 API")
 public interface CalendarControllerDocs {
@@ -17,18 +20,58 @@ public interface CalendarControllerDocs {
     @Operation(
             summary = "날짜 상세 조회",
             description = """
-					선택한 날짜의 OOTD 기록 상세를 조회합니다.
-					- CUSTOM 이미지가 존재하면 썸네일 타입은 CUSTOM
-					- CUSTOM이 없고 OOTD가 존재하면 썸네일 타입은 OOTD
-					- 기록이 없으면 200 + 빈 result 구조 반환
-					- date 형식이 틀리면 COMMON400
-					"""
+                    선택한 날짜의 OOTD 기록 상세를 조회합니다.
+                    - CUSTOM 이미지가 존재하면 썸네일 타입은 CUSTOM
+                    - CUSTOM이 없고 OOTD가 존재하면 썸네일 타입은 OOTD
+                    - 기록이 없으면 200 + 빈 result 구조 반환
+                    - date 형식이 틀리면 COMMON400
+                    """
     )
     CommonResponse<CalendarResponseDTO.EntryDetailResponse> getEntryDetail(
             @Parameter(hidden = true)
             @AuthenticationPrincipal(expression = "user") User user,
 
             @Parameter(description = "조회 날짜 (YYYY-MM-DD)", example = "2025-06-28")
+            @PathVariable("date") String date
+    );
+
+    @Operation(
+            summary = "날짜 캘린더 이미지 생성(OOTD 연결)",
+            description = """
+                    특정 날짜에 OOTD를 연결하거나 기존 기록을 수정합니다.
+                    - 하루 1개의 캘린더 기록만 유지 (user + date 기준)
+                    - 대표 이미지를 OOTD로 설정합니다.
+                    - date 형식이 틀리면 COMMON400 (date 형식이 올바르지 않습니다.)
+                    - OOTD가 없으면 CALENDAR4041
+                    - 해당 날짜 엔트리가 없으면 CALENDAR4042
+                    - 해당 날짜에 속하지 않은 OOTD면 COMMON400
+                    """
+    )
+    CommonResponse<CalendarResponseDTO.EntryDetailResponse> connectOotd(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "user") User user,
+
+            @Parameter(description = "대상 날짜 (YYYY-MM-DD)", example = "2025-06-28")
+            @PathVariable("date") String date,
+
+            // ✅ 구현체(CalendarController)와 동일하게 제약(@Valid) 맞춤
+            @RequestBody @Valid CalendarRequestDTO.ConnectOotdRequest request
+    );
+
+    @Operation(
+            summary = "날짜 캘린더 이미지 삭제(OOTD 연결 내역 삭제)",
+            description = """
+                    선택한 날짜의 OOTD 연결 내역을 삭제합니다.
+                    - 캘린더 엔트리 row를 삭제하는 것이 아니라 ootd 연결만 해제합니다.
+                    - date 형식이 틀리면 COMMON400 (date 형식이 올바르지 않습니다.)
+                    - 해당 날짜 캘린더 기록이 없으면 CALENDAR4040
+                    """
+    )
+    CommonResponse<CalendarResponseDTO.EntryDeleteResponse> disconnectOotd(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "user") User user,
+
+            @Parameter(description = "대상 날짜 (YYYY-MM-DD)", example = "2025-06-28")
             @PathVariable("date") String date
     );
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/controller/docs/CalendarControllerDocs.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/controller/docs/CalendarControllerDocs.java
@@ -58,8 +58,8 @@ public interface CalendarControllerDocs {
             summary = "날짜 기록 삭제",
             description = """
                     해당 날짜 calendars row 자체를 삭제합니다.
-                    - OOTD 연결 해제 ❌
-                    - row delete ✅
+                    - OOTD 연결 해제 
+                    - row delete 
                     - 기록이 없으면 CALENDAR4040
                     """
     )

--- a/src/main/java/com/nova/yeobaek/domain/calendar/controller/docs/CalendarControllerDocs.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/controller/docs/CalendarControllerDocs.java
@@ -1,7 +1,34 @@
 package com.nova.yeobaek.domain.calendar.controller.docs;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.nova.yeobaek.domain.calendar.dto.response.CalendarResponseDTO;
+import com.nova.yeobaek.domain.user.domain.User;
+import com.nova.yeobaek.global.payload.response.CommonResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Calendar", description = "달력 API")
 public interface CalendarControllerDocs {
+
+    @Operation(
+            summary = "날짜 상세 조회",
+            description = """
+					선택한 날짜의 OOTD 기록 상세를 조회합니다.
+					- CUSTOM 이미지가 존재하면 썸네일 타입은 CUSTOM
+					- CUSTOM이 없고 OOTD가 존재하면 썸네일 타입은 OOTD
+					- 기록이 없으면 200 + 빈 result 구조 반환
+					- date 형식이 틀리면 COMMON400
+					"""
+    )
+    CommonResponse<CalendarResponseDTO.EntryDetailResponse> getEntryDetail(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "user") User user,
+
+            @Parameter(description = "조회 날짜 (YYYY-MM-DD)", example = "2025-06-28")
+            @PathVariable("date") String date
+    );
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/controller/docs/CalendarControllerDocs.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/controller/docs/CalendarControllerDocs.java
@@ -20,10 +20,8 @@ public interface CalendarControllerDocs {
     @Operation(
             summary = "날짜 상세 조회",
             description = """
-                    선택한 날짜의 OOTD 기록 상세를 조회합니다.
-                    - CUSTOM 이미지가 존재하면 썸네일 타입은 CUSTOM
-                    - CUSTOM이 없고 OOTD가 존재하면 썸네일 타입은 OOTD
-                    - 기록이 없으면 200 + 빈 result 구조 반환
+                    선택한 날짜의 기록 상세를 조회합니다.
+                    - 기록이 없으면 200 + empty response
                     - date 형식이 틀리면 COMMON400
                     """
     )
@@ -31,47 +29,96 @@ public interface CalendarControllerDocs {
             @Parameter(hidden = true)
             @AuthenticationPrincipal(expression = "user") User user,
 
-            @Parameter(description = "조회 날짜 (YYYY-MM-DD)", example = "2025-06-28")
+            @Parameter(description = "조회 날짜 (YYYY-MM-DD)", example = "2026-01-13")
             @PathVariable("date") String date
     );
 
     @Operation(
-            summary = "날짜 캘린더 이미지 생성(OOTD 연결)",
+            summary = "날짜 기록 생성",
             description = """
-                    특정 날짜에 OOTD를 연결하거나 기존 기록을 수정합니다.
-                    - 하루 1개의 캘린더 기록만 유지 (user + date 기준)
-                    - 대표 이미지를 OOTD로 설정합니다.
-                    - date 형식이 틀리면 COMMON400 (date 형식이 올바르지 않습니다.)
-                    - OOTD가 없으면 CALENDAR4041
-                    - 해당 날짜 엔트리가 없으면 CALENDAR4042
-                    - 해당 날짜에 속하지 않은 OOTD면 COMMON400
+                    빈 날짜(기록 없음)에 캘린더 기록을 생성합니다.
+                    - POST에서만 calendars row 생성
+                    - OOTD 필수 (ootdId 필요)
+                    - 이미 해당 날짜 row가 있으면 CONFLICT4006
+                    - ootd가 없으면 CALENDAR4041
+                    - ootd가 해당 날짜가 아니면 COMMON400
                     """
     )
-    CommonResponse<CalendarResponseDTO.EntryDetailResponse> connectOotd(
+    CommonResponse<CalendarResponseDTO.EntryDetailResponse> createEntry(
             @Parameter(hidden = true)
             @AuthenticationPrincipal(expression = "user") User user,
 
-            @Parameter(description = "대상 날짜 (YYYY-MM-DD)", example = "2025-06-28")
+            @Parameter(description = "대상 날짜 (YYYY-MM-DD)", example = "2026-01-13")
             @PathVariable("date") String date,
 
-            // ✅ 구현체(CalendarController)와 동일하게 제약(@Valid) 맞춤
-            @RequestBody @Valid CalendarRequestDTO.ConnectOotdRequest request
+            @RequestBody @Valid CalendarRequestDTO.CreateEntryRequest request
     );
 
     @Operation(
-            summary = "날짜 캘린더 이미지 삭제(OOTD 연결 내역 삭제)",
+            summary = "날짜 기록 삭제",
             description = """
-                    선택한 날짜의 OOTD 연결 내역을 삭제합니다.
-                    - 캘린더 엔트리 row를 삭제하는 것이 아니라 ootd 연결만 해제합니다.
-                    - date 형식이 틀리면 COMMON400 (date 형식이 올바르지 않습니다.)
-                    - 해당 날짜 캘린더 기록이 없으면 CALENDAR4040
+                    해당 날짜 calendars row 자체를 삭제합니다.
+                    - OOTD 연결 해제 ❌
+                    - row delete ✅
+                    - 기록이 없으면 CALENDAR4040
                     """
     )
-    CommonResponse<CalendarResponseDTO.EntryDeleteResponse> disconnectOotd(
+    CommonResponse<CalendarResponseDTO.EntryDeleteResponse> deleteEntry(
             @Parameter(hidden = true)
             @AuthenticationPrincipal(expression = "user") User user,
 
-            @Parameter(description = "대상 날짜 (YYYY-MM-DD)", example = "2025-06-28")
+            @Parameter(description = "대상 날짜 (YYYY-MM-DD)", example = "2026-01-13")
             @PathVariable("date") String date
+    );
+
+    @Operation(
+            summary = "커스텀 이미지 추가",
+            description = """
+                    해당 날짜 calendars row에 커스텀 이미지를 저장합니다.
+                    - calendars row가 반드시 존재해야 함 (없으면 CALENDAR4040)
+                    """
+    )
+    CommonResponse<CalendarResponseDTO.EntryDetailResponse> addCustomImage(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "user") User user,
+
+            @Parameter(description = "대상 날짜 (YYYY-MM-DD)", example = "2026-01-13")
+            @PathVariable("date") String date,
+
+            @RequestBody @Valid CalendarRequestDTO.CustomImageRequest request
+    );
+
+    @Operation(
+            summary = "커스텀 이미지 삭제",
+            description = """
+                    해당 날짜 calendars row에서 커스텀 이미지만 삭제합니다.
+                    - 대표가 CUSTOM이었다면 thumbnail=OOTD로 자동 복귀
+                    - 커스텀이 없으면 CALENDAR4043
+                    """
+    )
+    CommonResponse<CalendarResponseDTO.EntryDetailResponse> deleteCustomImage(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "user") User user,
+
+            @Parameter(description = "대상 날짜 (YYYY-MM-DD)", example = "2026-01-13")
+            @PathVariable("date") String date
+    );
+
+    @Operation(
+            summary = "대표 이미지 선택",
+            description = """
+                    대표 이미지를 OOTD | CUSTOM 으로 선택합니다.
+                    - CUSTOM 선택 시 custom_image_url 필수 (없으면 COMMON400)
+                    - calendars row가 없으면 CALENDAR4040
+                    """
+    )
+    CommonResponse<CalendarResponseDTO.EntryDetailResponse> updateThumbnail(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "user") User user,
+
+            @Parameter(description = "대상 날짜 (YYYY-MM-DD)", example = "2026-01-13")
+            @PathVariable("date") String date,
+
+            @RequestBody @Valid CalendarRequestDTO.UpdateThumbnailRequest request
     );
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/converter/CalendarConverter.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/converter/CalendarConverter.java
@@ -16,11 +16,13 @@ public class CalendarConverter {
         Thumbnail thumbnail = null;
         String thumbnailImageUrl = null;
 
-        // ✅ 대표 이미지 규칙
+        //  대표 이미지 규칙
         if (hasOotd && hasCustom) {
             // 둘 다 있으면 DB 컬럼 thumbnail 기준
             thumbnail = calendar.getThumbnail();
-            thumbnailImageUrl = (thumbnail == Thumbnail.CUSTOM) ? calendar.getCustomImageUrl() : calendar.getOotdImageUrl();
+            thumbnailImageUrl = (thumbnail == Thumbnail.CUSTOM)
+                    ? calendar.getCustomImageUrl()
+                    : calendar.getOotdImageUrl();
         } else if (hasCustom) {
             thumbnail = Thumbnail.CUSTOM;
             thumbnailImageUrl = calendar.getCustomImageUrl();
@@ -29,20 +31,22 @@ public class CalendarConverter {
             thumbnailImageUrl = calendar.getOotdImageUrl();
         }
 
-        CalendarResponseDTO.EntryDetailResponse.OotdInfo ootdInfo = null;
+        //  record로 바뀌면 OotdInfo는 EntryDetailResponse 내부가 아니라 CalendarResponseDTO의 record로 사용
+        CalendarResponseDTO.OotdInfo ootdInfo = null;
         if (calendar.getOotd() != null) {
-            ootdInfo = CalendarResponseDTO.EntryDetailResponse.OotdInfo.builder()
-                    .ootdId(calendar.getOotd().getId())
-                    .ootdImageUrl(calendar.getOotdImageUrl())
-                    .build();
+            ootdInfo = new CalendarResponseDTO.OotdInfo(
+                    calendar.getOotd().getId(),
+                    calendar.getOotdImageUrl()
+            );
         }
 
-        return CalendarResponseDTO.EntryDetailResponse.builder()
-                .date(calendar.getDate().toString())
-                .thumbnail(thumbnail)
-                .thumbnailImageUrl(thumbnailImageUrl)
-                .ootd(ootdInfo)
-                .customImageUrl(calendar.getCustomImageUrl())
-                .build();
+        //  builder 제거 (record 생성자 사용)
+        return new CalendarResponseDTO.EntryDetailResponse(
+                calendar.getDate().toString(),
+                thumbnail,
+                thumbnailImageUrl,
+                ootdInfo,
+                calendar.getCustomImageUrl()
+        );
     }
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/converter/CalendarConverter.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/converter/CalendarConverter.java
@@ -3,33 +3,35 @@ package com.nova.yeobaek.domain.calendar.converter;
 import org.springframework.stereotype.Component;
 
 import com.nova.yeobaek.domain.calendar.domain.Calendar;
-import com.nova.yeobaek.domain.calendar.dto.response.CalendarResponseDTO;
-import com.nova.yeobaek.domain.calendar.dto.response.CalendarResponseDTO.EntryDetailResponse;
-import com.nova.yeobaek.domain.calendar.dto.response.CalendarResponseDTO.EntryDetailResponse.OotdInfo;
 import com.nova.yeobaek.domain.calendar.domain.enums.Thumbnail;
+import com.nova.yeobaek.domain.calendar.dto.response.CalendarResponseDTO;
 
 @Component
 public class CalendarConverter {
 
-    public EntryDetailResponse toEntryDetailResponse(Calendar calendar) {
+    public CalendarResponseDTO.EntryDetailResponse toEntryDetailResponse(Calendar calendar) {
+        boolean hasCustom = calendar.getCustomImageUrl() != null && !calendar.getCustomImageUrl().isBlank();
+        boolean hasOotd = calendar.getOotdImageUrl() != null && !calendar.getOotdImageUrl().isBlank(); // row 존재 시 사실상 true
+
         Thumbnail thumbnail = null;
         String thumbnailImageUrl = null;
 
-        // 1) CUSTOM 이미지가 있으면 CUSTOM 우선
-        if (calendar.getCustomImageUrl() != null && !calendar.getCustomImageUrl().isBlank()) {
+        // ✅ 대표 이미지 규칙
+        if (hasOotd && hasCustom) {
+            // 둘 다 있으면 DB 컬럼 thumbnail 기준
+            thumbnail = calendar.getThumbnail();
+            thumbnailImageUrl = (thumbnail == Thumbnail.CUSTOM) ? calendar.getCustomImageUrl() : calendar.getOotdImageUrl();
+        } else if (hasCustom) {
             thumbnail = Thumbnail.CUSTOM;
             thumbnailImageUrl = calendar.getCustomImageUrl();
-        }
-        // 2) CUSTOM 없고 OOTD 있으면 OOTD
-        else if (calendar.getOotd() != null) {
+        } else if (hasOotd) {
             thumbnail = Thumbnail.OOTD;
-            // Calendar 테이블에 ootdImageUrl이 필수로 있으니 그 값을 썸네일로 사용
             thumbnailImageUrl = calendar.getOotdImageUrl();
         }
 
-        OotdInfo ootdInfo = null;
+        CalendarResponseDTO.EntryDetailResponse.OotdInfo ootdInfo = null;
         if (calendar.getOotd() != null) {
-            ootdInfo = OotdInfo.builder()
+            ootdInfo = CalendarResponseDTO.EntryDetailResponse.OotdInfo.builder()
                     .ootdId(calendar.getOotd().getId())
                     .ootdImageUrl(calendar.getOotdImageUrl())
                     .build();

--- a/src/main/java/com/nova/yeobaek/domain/calendar/converter/CalendarConverter.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/converter/CalendarConverter.java
@@ -1,4 +1,46 @@
 package com.nova.yeobaek.domain.calendar.converter;
 
+import org.springframework.stereotype.Component;
+
+import com.nova.yeobaek.domain.calendar.domain.Calendar;
+import com.nova.yeobaek.domain.calendar.dto.response.CalendarResponseDTO;
+import com.nova.yeobaek.domain.calendar.dto.response.CalendarResponseDTO.EntryDetailResponse;
+import com.nova.yeobaek.domain.calendar.dto.response.CalendarResponseDTO.EntryDetailResponse.OotdInfo;
+import com.nova.yeobaek.domain.calendar.domain.enums.Thumbnail;
+
+@Component
 public class CalendarConverter {
+
+    public EntryDetailResponse toEntryDetailResponse(Calendar calendar) {
+        Thumbnail thumbnail = null;
+        String thumbnailImageUrl = null;
+
+        // 1) CUSTOM 이미지가 있으면 CUSTOM 우선
+        if (calendar.getCustomImageUrl() != null && !calendar.getCustomImageUrl().isBlank()) {
+            thumbnail = Thumbnail.CUSTOM;
+            thumbnailImageUrl = calendar.getCustomImageUrl();
+        }
+        // 2) CUSTOM 없고 OOTD 있으면 OOTD
+        else if (calendar.getOotd() != null) {
+            thumbnail = Thumbnail.OOTD;
+            // Calendar 테이블에 ootdImageUrl이 필수로 있으니 그 값을 썸네일로 사용
+            thumbnailImageUrl = calendar.getOotdImageUrl();
+        }
+
+        OotdInfo ootdInfo = null;
+        if (calendar.getOotd() != null) {
+            ootdInfo = OotdInfo.builder()
+                    .ootdId(calendar.getOotd().getId())
+                    .ootdImageUrl(calendar.getOotdImageUrl())
+                    .build();
+        }
+
+        return CalendarResponseDTO.EntryDetailResponse.builder()
+                .date(calendar.getDate().toString())
+                .thumbnail(thumbnail)
+                .thumbnailImageUrl(thumbnailImageUrl)
+                .ootd(ootdInfo)
+                .customImageUrl(calendar.getCustomImageUrl())
+                .build();
+    }
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/domain/Calendar.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/domain/Calendar.java
@@ -35,12 +35,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
 @DynamicUpdate
-@Table(name = "calendars",
-	uniqueConstraints = {
-		@UniqueConstraint(
-			name = "uk_user_date",
-			columnNames = {"user_id", "date"})
-})
+@Table(
+		name = "calendars",
+		uniqueConstraints = {
+				@UniqueConstraint(
+						name = "uk_user_date",
+						columnNames = {"user_id", "date"}
+				)
+		}
+)
 public class Calendar extends BaseEntity {
 
 	@Id
@@ -67,4 +70,24 @@ public class Calendar extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "ootd_id")
 	private OOTD ootd;
+
+	/**
+	 * 대표 이미지를 OOTD로 설정 (CUSTOM 있으면 제거해서 썸네일이 OOTD로 나오게)
+	 */
+	public void connectOotd(OOTD ootd) {
+		this.ootd = ootd;
+		this.ootdImageUrl = ootd.getImageUrl();   // CalendarConverter가 이 값을 썸네일로 사용
+		this.customImageUrl = null;               // "대표 이미지를 OOTD로" 명세 반영
+		this.thumbnail = Thumbnail.OOTD;
+	}
+
+	/**
+	 * OOTD 연결 해제 (엔트리 row 삭제 아님)
+	 * ootdImageUrl 컬럼이 NOT NULL이라 null로는 안 만듦.
+	 */
+	public void disconnectOotd() {
+		this.ootd = null;
+		// 썸네일은 customImageUrl이 있으면 CUSTOM로, 없으면 "기록 없음"처럼 내려가게 됨(Converter 로직)
+		// ootdImageUrl은 NOT NULL 컬럼이라 유지
+	}
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/domain/Calendar.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/domain/Calendar.java
@@ -72,22 +72,36 @@ public class Calendar extends BaseEntity {
 	private OOTD ootd;
 
 	/**
-	 * 대표 이미지를 OOTD로 설정 (CUSTOM 있으면 제거해서 썸네일이 OOTD로 나오게)
+	 * ✅ OOTD 연결(혹은 생성 시 세팅) - customImageUrl 건드리면 안 됨
 	 */
 	public void connectOotd(OOTD ootd) {
 		this.ootd = ootd;
-		this.ootdImageUrl = ootd.getImageUrl();   // CalendarConverter가 이 값을 썸네일로 사용
-		this.customImageUrl = null;               // "대표 이미지를 OOTD로" 명세 반영
+		this.ootdImageUrl = ootd.getImageUrl();
 		this.thumbnail = Thumbnail.OOTD;
 	}
 
 	/**
-	 * OOTD 연결 해제 (엔트리 row 삭제 아님)
-	 * ootdImageUrl 컬럼이 NOT NULL이라 null로는 안 만듦.
+	 * ❌ 최종 정책에서 사용 금지 (row 삭제가 정답)
 	 */
+	@Deprecated
 	public void disconnectOotd() {
 		this.ootd = null;
-		// 썸네일은 customImageUrl이 있으면 CUSTOM로, 없으면 "기록 없음"처럼 내려가게 됨(Converter 로직)
-		// ootdImageUrl은 NOT NULL 컬럼이라 유지
+		// NOT NULL 컬럼(ootdImageUrl)은 유지
+	}
+
+	public void setCustomImage(String imageUrl) {
+		this.customImageUrl = imageUrl;
+		// 대표는 별도 PATCH로 선택하므로 여기서는 thumbnail 변경 X
+	}
+
+	public void removeCustomImageAndFallbackThumbnail() {
+		this.customImageUrl = null;
+		if (this.thumbnail == Thumbnail.CUSTOM) {
+			this.thumbnail = Thumbnail.OOTD;
+		}
+	}
+
+	public void changeThumbnail(Thumbnail thumbnail) {
+		this.thumbnail = thumbnail;
 	}
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/domain/enums/Thumbnail.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/domain/enums/Thumbnail.java
@@ -1,5 +1,20 @@
 package com.nova.yeobaek.domain.calendar.domain.enums;
 
+import java.util.Arrays;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public enum Thumbnail {
-	OOTD, CUSTOM;
+	OOTD,
+	CUSTOM;
+
+	@JsonCreator
+	public static Thumbnail from(String value) {
+		if (value == null) return null;
+
+		return Arrays.stream(values())
+				.filter(v -> v.name().equalsIgnoreCase(value)) // 대소문자까지 허용하려면
+				.findFirst()
+				.orElse(null); //  없는 값이면 null → DTO @NotNull에서 걸림
+	}
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/dto/request/CalendarRequestDTO.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/dto/request/CalendarRequestDTO.java
@@ -1,4 +1,20 @@
 package com.nova.yeobaek.domain.calendar.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class CalendarRequestDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ConnectOotdRequest {
+
+        @NotNull(message = "ootdId는 필수입니다.")
+        private Long ootdId;
+    }
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/dto/request/CalendarRequestDTO.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/dto/request/CalendarRequestDTO.java
@@ -1,5 +1,8 @@
 package com.nova.yeobaek.domain.calendar.dto.request;
 
+import com.nova.yeobaek.domain.calendar.domain.enums.Thumbnail;
+
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,9 +15,26 @@ public class CalendarRequestDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ConnectOotdRequest {
-
+    public static class CreateEntryRequest {
         @NotNull(message = "ootdId는 필수입니다.")
         private Long ootdId;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CustomImageRequest {
+        @NotBlank(message = "imageUrl은 필수입니다.")
+        private String imageUrl;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateThumbnailRequest {
+        @NotNull(message = "thumbnail은 필수입니다.")
+        private Thumbnail thumbnail; // OOTD | CUSTOM
     }
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/dto/request/CalendarRequestDTO.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/dto/request/CalendarRequestDTO.java
@@ -1,40 +1,23 @@
 package com.nova.yeobaek.domain.calendar.dto.request;
 
 import com.nova.yeobaek.domain.calendar.domain.enums.Thumbnail;
-
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 public class CalendarRequestDTO {
 
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class CreateEntryRequest {
-        @NotNull(message = "ootdId는 필수입니다.")
-        private Long ootdId;
-    }
+    public record CreateEntryRequest(
+            @NotNull(message = "ootdId는 필수입니다.")
+            Long ootdId
+    ) {}
 
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class CustomImageRequest {
-        @NotBlank(message = "imageUrl은 필수입니다.")
-        private String imageUrl;
-    }
+    public record CustomImageRequest(
+            @NotBlank(message = "imageUrl은 필수입니다.")
+            String imageUrl
+    ) {}
 
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class UpdateThumbnailRequest {
-        @NotNull(message = "thumbnail은 필수입니다.")
-        private Thumbnail thumbnail; // OOTD | CUSTOM
-    }
+    public record UpdateThumbnailRequest(
+            @NotNull(message = "thumbnail은 필수입니다.")
+            Thumbnail thumbnail // OOTD | CUSTOM
+    ) {}
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/dto/response/CalendarResponseDTO.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/dto/response/CalendarResponseDTO.java
@@ -2,52 +2,33 @@ package com.nova.yeobaek.domain.calendar.dto.response;
 
 import com.nova.yeobaek.domain.calendar.domain.enums.Thumbnail;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 public class CalendarResponseDTO {
 
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class EntryDetailResponse {
-
-        private String date;                 // YYYY-MM-DD
-        private Thumbnail thumbnail;         // CUSTOM / OOTD (없으면 null)
-        private String thumbnailImageUrl;    // 썸네일 이미지 URL (없으면 null)
-
-        private OotdInfo ootd;               // 없으면 null
-        private String customImageUrl;       // 없으면 null
-
-        @Getter
-        @Builder
-        @NoArgsConstructor
-        @AllArgsConstructor
-        public static class OotdInfo {
-            private Long ootdId;
-            private String ootdImageUrl;
-        }
-
+    public record EntryDetailResponse(
+            String date,                 // YYYY-MM-DD
+            Thumbnail thumbnail,          // CUSTOM / OOTD (없으면 null)
+            String thumbnailImageUrl,     // 썸네일 이미지 URL (없으면 null)
+            OotdInfo ootd,                // 없으면 null
+            String customImageUrl         // 없으면 null
+    ) {
         public static EntryDetailResponse empty(String date) {
-            return EntryDetailResponse.builder()
-                    .date(date)
-                    .thumbnail(null)
-                    .thumbnailImageUrl(null)
-                    .ootd(null)
-                    .customImageUrl(null)
-                    .build();
+            return new EntryDetailResponse(
+                    date,
+                    null,
+                    null,
+                    null,
+                    null
+            );
         }
     }
 
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class EntryDeleteResponse {
-        private String date;
-        private Boolean deleted;
-    }
+    public record OotdInfo(
+            Long ootdId,
+            String ootdImageUrl
+    ) {}
+
+    public record EntryDeleteResponse(
+            String date,
+            boolean deleted
+    ) {}
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/dto/response/CalendarResponseDTO.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/dto/response/CalendarResponseDTO.java
@@ -41,4 +41,13 @@ public class CalendarResponseDTO {
                     .build();
         }
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EntryDeleteResponse {
+        private String date;
+        private Boolean deleted;
+    }
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/dto/response/CalendarResponseDTO.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/dto/response/CalendarResponseDTO.java
@@ -1,4 +1,44 @@
 package com.nova.yeobaek.domain.calendar.dto.response;
 
+import com.nova.yeobaek.domain.calendar.domain.enums.Thumbnail;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class CalendarResponseDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EntryDetailResponse {
+
+        private String date;                 // YYYY-MM-DD
+        private Thumbnail thumbnail;         // CUSTOM / OOTD (없으면 null)
+        private String thumbnailImageUrl;    // 썸네일 이미지 URL (없으면 null)
+
+        private OotdInfo ootd;               // 없으면 null
+        private String customImageUrl;       // 없으면 null
+
+        @Getter
+        @Builder
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class OotdInfo {
+            private Long ootdId;
+            private String ootdImageUrl;
+        }
+
+        public static EntryDetailResponse empty(String date) {
+            return EntryDetailResponse.builder()
+                    .date(date)
+                    .thumbnail(null)
+                    .thumbnailImageUrl(null)
+                    .ootd(null)
+                    .customImageUrl(null)
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/exception/CalendarException.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/exception/CalendarException.java
@@ -1,0 +1,11 @@
+package com.nova.yeobaek.domain.calendar.exception;
+
+import com.nova.yeobaek.domain.calendar.status.CalendarErrorStatus;
+import com.nova.yeobaek.global.payload.exception.GeneralException;
+
+public class CalendarException extends GeneralException {
+
+    public CalendarException(CalendarErrorStatus status) {
+        super(status);
+    }
+}

--- a/src/main/java/com/nova/yeobaek/domain/calendar/repository/CalendarRepository.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/repository/CalendarRepository.java
@@ -1,8 +1,15 @@
 package com.nova.yeobaek.domain.calendar.repository;
 
+import java.time.LocalDate;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.nova.yeobaek.domain.calendar.domain.Calendar;
 
-public interface CalendarRepository extends JpaRepository<Calendar, Long>, CalendarRepositoryCustom {
+public interface CalendarRepository extends JpaRepository<Calendar, Long> {
+
+    Optional<Calendar> findByUserIdAndDate(Long userId, LocalDate date);
+    // 만약 위 메서드가 인식 안 되면 아래로 대체:
+    // Optional<Calendar> findByUser_IdAndDate(Long userId, LocalDate date);
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/repository/CalendarRepositoryCustom.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/repository/CalendarRepositoryCustom.java
@@ -1,4 +1,12 @@
 package com.nova.yeobaek.domain.calendar.repository;
 
+import java.time.LocalDate;
+import java.util.Optional;
+
+import com.nova.yeobaek.domain.calendar.domain.Calendar;
+
 public interface CalendarRepositoryCustom {
+
+    Optional<Calendar> findByUserIdAndDate(Long userId, LocalDate date);
 }
+

--- a/src/main/java/com/nova/yeobaek/domain/calendar/repository/CalendarRepositoryImpl.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/repository/CalendarRepositoryImpl.java
@@ -1,10 +1,32 @@
 package com.nova.yeobaek.domain.calendar.repository;
 
-import org.springframework.stereotype.Repository;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import com.nova.yeobaek.domain.calendar.domain.Calendar;
+import com.nova.yeobaek.domain.calendar.domain.QCalendar;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 
-@Repository
 @RequiredArgsConstructor
 public class CalendarRepositoryImpl implements CalendarRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Calendar> findByUserIdAndDate(Long userId, LocalDate date) {
+        QCalendar calendar = QCalendar.calendar;
+
+        Calendar result = queryFactory
+                .selectFrom(calendar)
+                .where(
+                        // ✅ 기존: calendar.userId.eq(userId)  (필드 없음)
+                        calendar.user.id.eq(userId),
+                        calendar.date.eq(date)
+                )
+                .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/service/CalendarService.java
@@ -9,14 +9,16 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.nova.yeobaek.domain.calendar.converter.CalendarConverter;
 import com.nova.yeobaek.domain.calendar.domain.Calendar;
-import com.nova.yeobaek.domain.calendar.domain.enums.Thumbnail; // ✅ 프로젝트에 맞게 존재해야 함 (OOTD/CUSTOM)
+import com.nova.yeobaek.domain.calendar.domain.enums.Thumbnail;
 import com.nova.yeobaek.domain.calendar.dto.response.CalendarResponseDTO;
 import com.nova.yeobaek.domain.calendar.repository.CalendarRepository;
 import com.nova.yeobaek.domain.calendar.status.CalendarErrorStatus;
 import com.nova.yeobaek.domain.ootd.domain.OOTD;
 import com.nova.yeobaek.domain.ootd.repository.OOTDRepository;
+import com.nova.yeobaek.domain.user.domain.User;
 import com.nova.yeobaek.domain.user.repository.UserRepository;
 import com.nova.yeobaek.global.payload.exception.GeneralException;
+import com.nova.yeobaek.global.payload.status.CommonErrorStatus;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,17 +31,13 @@ public class CalendarService {
 
     private final CalendarRepository calendarRepository;
     private final CalendarConverter calendarConverter;
+
     private final OOTDRepository ootdRepository;
     private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
     public CalendarResponseDTO.EntryDetailResponse getEntryDetail(Long userId, String date) {
-        LocalDate parsedDate;
-        try {
-            parsedDate = LocalDate.parse(date); // YYYY-MM-DD
-        } catch (DateTimeParseException e) {
-            throw new GeneralException(CalendarErrorStatus.INVALID_DATE);
-        }
+        LocalDate parsedDate = parseDateOrThrow(date);
 
         return calendarRepository.findByUserIdAndDate(userId, parsedDate)
                 .map(calendarConverter::toEntryDetailResponse)
@@ -47,59 +45,56 @@ public class CalendarService {
     }
 
     /**
-     * ✅ Upsert 버전
-     *
-     * POST /api/calendar/entries/{date}
-     * - 엔트리 있으면 update
-     * - 엔트리 없으면 insert 후 update (자동 생성)
-     * - ootd 존재해야 함 (없으면 CALENDAR4041)
-     * - ootd.createdAt.toLocalDate() == date 여야 함 (아니면 OOTD_NOT_IN_DATE)
+     * ✅ POST /api/calendar/entries/{date}
+     * - "기록 없는 날짜"는 row 자체가 없어야 하므로, 여기서만 row를 생성한다.
+     * - ootdId 필수
+     * - ootd.createdAt.toLocalDate() == date 검증
+     * - 이미 존재하면 CONFLICT4006 (DUPLICATED_CALENDAR_CREATE)
      */
-    public CalendarResponseDTO.EntryDetailResponse connectOotd(Long userId, String date, Long ootdId) {
-        LocalDate parsedDate;
-        try {
-            parsedDate = LocalDate.parse(date);
-        } catch (DateTimeParseException e) {
-            throw new GeneralException(CalendarErrorStatus.INVALID_DATE);
-        }
+    public CalendarResponseDTO.EntryDetailResponse createEntry(Long userId, String date, Long ootdId) {
+        LocalDate parsedDate = parseDateOrThrow(date);
 
-        // ✅ OOTD 존재 검증
         OOTD ootd = ootdRepository.findById(ootdId)
                 .orElseThrow(() -> new GeneralException(CalendarErrorStatus.CALENDAR4041));
 
-        // ✅ "해당 날짜에 속하지 않은 OOTD" 검증
         if (ootd.getCreatedAt() == null || !ootd.getCreatedAt().toLocalDate().equals(parsedDate)) {
             throw new GeneralException(CalendarErrorStatus.OOTD_NOT_IN_DATE);
         }
 
-        // ✅ 엔트리 없으면 자동 생성(upsert)
-        Calendar calendar = getOrCreateCalendar(userId, parsedDate);
+        User userRef = userRepository.getReferenceById(userId);
 
-        // ✅ 대표 이미지를 OOTD로 설정
-        calendar.connectOotd(ootd);
+        Calendar calendar = Calendar.builder()
+                .user(userRef)
+                .date(parsedDate)
+                .ootd(ootd)
+                .ootdImageUrl(ootd.getImageUrl())
+                .customImageUrl(null)
+                .thumbnail(Thumbnail.OOTD)
+                .build();
+
+        try {
+            calendarRepository.save(calendar);
+        } catch (DataIntegrityViolationException e) {
+            // UNIQUE(user_id, date) 충돌
+            throw new GeneralException(CommonErrorStatus.DUPLICATED_CALENDAR_CREATE);
+        }
 
         return calendarConverter.toEntryDetailResponse(calendar);
     }
 
     /**
-     * DELETE /api/calendar/entries/{date}
-     * - row 삭제가 아니라 "OOTD 연결 내역 삭제" (ootd=null)
-     * - ✅ Upsert 정책에서 DELETE는 보통 멱등(idempotent) 처리:
-     *   엔트리가 없어도 200으로 "삭제됨" 응답 (프론트/테스트 편함)
+     * ✅ DELETE /api/calendar/entries/{date}
+     * - OOTD 연결 해제 ❌
+     * - calendars row 자체 삭제 ✅
+     * - 없으면 CALENDAR4040
      */
-    public CalendarResponseDTO.EntryDeleteResponse disconnectOotd(Long userId, String date) {
-        LocalDate parsedDate;
-        try {
-            parsedDate = LocalDate.parse(date);
-        } catch (DateTimeParseException e) {
-            throw new GeneralException(CalendarErrorStatus.INVALID_DATE);
-        }
+    public CalendarResponseDTO.EntryDeleteResponse deleteEntry(Long userId, String date) {
+        LocalDate parsedDate = parseDateOrThrow(date);
 
-        Calendar calendar = calendarRepository.findByUserIdAndDate(userId, parsedDate).orElse(null);
+        Calendar calendar = calendarRepository.findByUserIdAndDate(userId, parsedDate)
+                .orElseThrow(() -> new GeneralException(CalendarErrorStatus.CALENDAR4040));
 
-        if (calendar != null) {
-            calendar.disconnectOotd();
-        }
+        calendarRepository.delete(calendar);
 
         return CalendarResponseDTO.EntryDeleteResponse.builder()
                 .date(parsedDate.toString())
@@ -108,38 +103,67 @@ public class CalendarService {
     }
 
     /**
-     * calendars 테이블 제약(NOT NULL / uk_user_date) 때문에
-     * 엔트리 없으면 "기본값" 채워서 생성해야 함.
+     * ✅ POST /api/calendar/entries/{date}/custom-image
+     * - calendars row 반드시 존재해야 함 (없으면 CALENDAR4040)
      */
-    private Calendar getOrCreateCalendar(Long userId, LocalDate date) {
-        return calendarRepository.findByUserIdAndDate(userId, date)
-                .orElseGet(() -> {
-                    try {
-                        Calendar created = Calendar.builder()
-                                // FK만 잡고 싶으면 getReferenceById가 제일 가벼움
-                                .user(userRepository.getReferenceById(userId))
-                                .date(date)
+    public CalendarResponseDTO.EntryDetailResponse addCustomImage(Long userId, String date, String imageUrl) {
+        LocalDate parsedDate = parseDateOrThrow(date);
 
-                                // ✅ DB에서 ootd_image_url NOT NULL 이라 빈 문자열로라도 채워야 함
-                                .ootdImageUrl("")
+        Calendar calendar = calendarRepository.findByUserIdAndDate(userId, parsedDate)
+                .orElseThrow(() -> new GeneralException(CalendarErrorStatus.CALENDAR4040));
 
-                                // ✅ thumbnail NOT NULL (DB default가 있더라도 안전하게 세팅)
-                                .thumbnail(Thumbnail.OOTD)
+        calendar.setCustomImage(imageUrl);
 
-                                // ootdId는 연결 전이므로 null
-                                .ootd(null)
+        return calendarConverter.toEntryDetailResponse(calendar);
+    }
 
-                                // customImageUrl은 null 가능
-                                .customImageUrl(null)
-                                .build();
+    /**
+     * ✅ DELETE /api/calendar/entries/{date}/custom-image
+     * - custom 이미지만 삭제
+     * - 대표가 CUSTOM이었다면 thumbnail = OOTD로 복귀
+     */
+    public CalendarResponseDTO.EntryDetailResponse deleteCustomImage(Long userId, String date) {
+        LocalDate parsedDate = parseDateOrThrow(date);
 
-                        return calendarRepository.save(created);
+        Calendar calendar = calendarRepository.findByUserIdAndDate(userId, parsedDate)
+                .orElseThrow(() -> new GeneralException(CalendarErrorStatus.CALENDAR4040));
 
-                    } catch (DataIntegrityViolationException e) {
-                        // 동시성/중복 요청으로 uk_user_date에 걸릴 수 있음 -> 다시 조회해서 반환
-                        return calendarRepository.findByUserIdAndDate(userId, date)
-                                .orElseThrow(() -> e);
-                    }
-                });
+        if (calendar.getCustomImageUrl() == null || calendar.getCustomImageUrl().isBlank()) {
+            throw new GeneralException(CalendarErrorStatus.CALENDAR4043);
+        }
+
+        calendar.removeCustomImageAndFallbackThumbnail();
+
+        return calendarConverter.toEntryDetailResponse(calendar);
+    }
+
+    /**
+     * ✅ PATCH /api/calendar/entries/{date}/thumbnail
+     * - OOTD | CUSTOM
+     * - CUSTOM 선택 시 custom_image_url 필수
+     */
+    public CalendarResponseDTO.EntryDetailResponse updateThumbnail(Long userId, String date, Thumbnail thumbnail) {
+        LocalDate parsedDate = parseDateOrThrow(date);
+
+        Calendar calendar = calendarRepository.findByUserIdAndDate(userId, parsedDate)
+                .orElseThrow(() -> new GeneralException(CalendarErrorStatus.CALENDAR4040));
+
+        if (thumbnail == Thumbnail.CUSTOM) {
+            if (calendar.getCustomImageUrl() == null || calendar.getCustomImageUrl().isBlank()) {
+                throw new GeneralException(CalendarErrorStatus.CUSTOM_IMAGE_REQUIRED);
+            }
+        }
+
+        calendar.changeThumbnail(thumbnail);
+
+        return calendarConverter.toEntryDetailResponse(calendar);
+    }
+
+    private LocalDate parseDateOrThrow(String date) {
+        try {
+            return LocalDate.parse(date);
+        } catch (DateTimeParseException e) {
+            throw new GeneralException(CalendarErrorStatus.INVALID_DATE);
+        }
     }
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/service/CalendarService.java
@@ -11,14 +11,13 @@ import com.nova.yeobaek.domain.calendar.converter.CalendarConverter;
 import com.nova.yeobaek.domain.calendar.domain.Calendar;
 import com.nova.yeobaek.domain.calendar.domain.enums.Thumbnail;
 import com.nova.yeobaek.domain.calendar.dto.response.CalendarResponseDTO;
+import com.nova.yeobaek.domain.calendar.exception.CalendarException;
 import com.nova.yeobaek.domain.calendar.repository.CalendarRepository;
 import com.nova.yeobaek.domain.calendar.status.CalendarErrorStatus;
 import com.nova.yeobaek.domain.ootd.domain.OOTD;
 import com.nova.yeobaek.domain.ootd.repository.OOTDRepository;
 import com.nova.yeobaek.domain.user.domain.User;
 import com.nova.yeobaek.domain.user.repository.UserRepository;
-import com.nova.yeobaek.global.payload.exception.GeneralException;
-import com.nova.yeobaek.global.payload.status.CommonErrorStatus;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,20 +44,20 @@ public class CalendarService {
     }
 
     /**
-     * ✅ POST /api/calendar/entries/{date}
+     *  POST /api/calendar/entries/{date}
      * - "기록 없는 날짜"는 row 자체가 없어야 하므로, 여기서만 row를 생성한다.
      * - ootdId 필수
      * - ootd.createdAt.toLocalDate() == date 검증
-     * - 이미 존재하면 CONFLICT4006 (DUPLICATED_CALENDAR_CREATE)
+     * - 이미 존재하면 DUPLICATED_CALENDAR_CREATE
      */
     public CalendarResponseDTO.EntryDetailResponse createEntry(Long userId, String date, Long ootdId) {
         LocalDate parsedDate = parseDateOrThrow(date);
 
         OOTD ootd = ootdRepository.findById(ootdId)
-                .orElseThrow(() -> new GeneralException(CalendarErrorStatus.CALENDAR4041));
+                .orElseThrow(() -> new CalendarException(CalendarErrorStatus.CALENDAR4041));
 
         if (ootd.getCreatedAt() == null || !ootd.getCreatedAt().toLocalDate().equals(parsedDate)) {
-            throw new GeneralException(CalendarErrorStatus.OOTD_NOT_IN_DATE);
+            throw new CalendarException(CalendarErrorStatus.OOTD_NOT_IN_DATE);
         }
 
         User userRef = userRepository.getReferenceById(userId);
@@ -75,42 +74,40 @@ public class CalendarService {
         try {
             calendarRepository.save(calendar);
         } catch (DataIntegrityViolationException e) {
-            // UNIQUE(user_id, date) 충돌
-            throw new GeneralException(CommonErrorStatus.DUPLICATED_CALENDAR_CREATE);
+            throw new CalendarException(CalendarErrorStatus.DUPLICATED_CALENDAR_CREATE);
         }
 
         return calendarConverter.toEntryDetailResponse(calendar);
     }
 
     /**
-     * ✅ DELETE /api/calendar/entries/{date}
-     * - OOTD 연결 해제 ❌
-     * - calendars row 자체 삭제 ✅
+     *  DELETE /api/calendar/entries/{date}
+     * - calendars row 자체 삭제
      * - 없으면 CALENDAR4040
      */
     public CalendarResponseDTO.EntryDeleteResponse deleteEntry(Long userId, String date) {
         LocalDate parsedDate = parseDateOrThrow(date);
 
         Calendar calendar = calendarRepository.findByUserIdAndDate(userId, parsedDate)
-                .orElseThrow(() -> new GeneralException(CalendarErrorStatus.CALENDAR4040));
+                .orElseThrow(() -> new CalendarException(CalendarErrorStatus.CALENDAR4040));
 
         calendarRepository.delete(calendar);
 
-        return CalendarResponseDTO.EntryDeleteResponse.builder()
-                .date(parsedDate.toString())
-                .deleted(true)
-                .build();
+        return new CalendarResponseDTO.EntryDeleteResponse(
+                parsedDate.toString(),
+                true
+        );
     }
 
     /**
-     * ✅ POST /api/calendar/entries/{date}/custom-image
+     *  POST /api/calendar/entries/{date}/custom-image
      * - calendars row 반드시 존재해야 함 (없으면 CALENDAR4040)
      */
     public CalendarResponseDTO.EntryDetailResponse addCustomImage(Long userId, String date, String imageUrl) {
         LocalDate parsedDate = parseDateOrThrow(date);
 
         Calendar calendar = calendarRepository.findByUserIdAndDate(userId, parsedDate)
-                .orElseThrow(() -> new GeneralException(CalendarErrorStatus.CALENDAR4040));
+                .orElseThrow(() -> new CalendarException(CalendarErrorStatus.CALENDAR4040));
 
         calendar.setCustomImage(imageUrl);
 
@@ -118,18 +115,18 @@ public class CalendarService {
     }
 
     /**
-     * ✅ DELETE /api/calendar/entries/{date}/custom-image
+     *  DELETE /api/calendar/entries/{date}/custom-image
      * - custom 이미지만 삭제
-     * - 대표가 CUSTOM이었다면 thumbnail = OOTD로 복귀
+     * - 삭제할 custom이 없으면 CALENDAR4043
      */
     public CalendarResponseDTO.EntryDetailResponse deleteCustomImage(Long userId, String date) {
         LocalDate parsedDate = parseDateOrThrow(date);
 
         Calendar calendar = calendarRepository.findByUserIdAndDate(userId, parsedDate)
-                .orElseThrow(() -> new GeneralException(CalendarErrorStatus.CALENDAR4040));
+                .orElseThrow(() -> new CalendarException(CalendarErrorStatus.CALENDAR4040));
 
         if (calendar.getCustomImageUrl() == null || calendar.getCustomImageUrl().isBlank()) {
-            throw new GeneralException(CalendarErrorStatus.CALENDAR4043);
+            throw new CalendarException(CalendarErrorStatus.CALENDAR4043);
         }
 
         calendar.removeCustomImageAndFallbackThumbnail();
@@ -138,7 +135,7 @@ public class CalendarService {
     }
 
     /**
-     * ✅ PATCH /api/calendar/entries/{date}/thumbnail
+     *  PATCH /api/calendar/entries/{date}/thumbnail
      * - OOTD | CUSTOM
      * - CUSTOM 선택 시 custom_image_url 필수
      */
@@ -146,11 +143,11 @@ public class CalendarService {
         LocalDate parsedDate = parseDateOrThrow(date);
 
         Calendar calendar = calendarRepository.findByUserIdAndDate(userId, parsedDate)
-                .orElseThrow(() -> new GeneralException(CalendarErrorStatus.CALENDAR4040));
+                .orElseThrow(() -> new CalendarException(CalendarErrorStatus.CALENDAR4040));
 
         if (thumbnail == Thumbnail.CUSTOM) {
             if (calendar.getCustomImageUrl() == null || calendar.getCustomImageUrl().isBlank()) {
-                throw new GeneralException(CalendarErrorStatus.CUSTOM_IMAGE_REQUIRED);
+                throw new CalendarException(CalendarErrorStatus.CUSTOM_IMAGE_REQUIRED);
             }
         }
 
@@ -163,7 +160,7 @@ public class CalendarService {
         try {
             return LocalDate.parse(date);
         } catch (DateTimeParseException e) {
-            throw new GeneralException(CalendarErrorStatus.INVALID_DATE);
+            throw new CalendarException(CalendarErrorStatus.INVALID_DATE);
         }
     }
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/service/CalendarService.java
@@ -3,14 +3,20 @@ package com.nova.yeobaek.domain.calendar.service;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.nova.yeobaek.domain.calendar.converter.CalendarConverter;
+import com.nova.yeobaek.domain.calendar.domain.Calendar;
+import com.nova.yeobaek.domain.calendar.domain.enums.Thumbnail; // ✅ 프로젝트에 맞게 존재해야 함 (OOTD/CUSTOM)
 import com.nova.yeobaek.domain.calendar.dto.response.CalendarResponseDTO;
 import com.nova.yeobaek.domain.calendar.repository.CalendarRepository;
+import com.nova.yeobaek.domain.calendar.status.CalendarErrorStatus;
+import com.nova.yeobaek.domain.ootd.domain.OOTD;
+import com.nova.yeobaek.domain.ootd.repository.OOTDRepository;
+import com.nova.yeobaek.domain.user.repository.UserRepository;
 import com.nova.yeobaek.global.payload.exception.GeneralException;
-import com.nova.yeobaek.global.payload.status.CommonErrorStatus;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +29,8 @@ public class CalendarService {
 
     private final CalendarRepository calendarRepository;
     private final CalendarConverter calendarConverter;
+    private final OOTDRepository ootdRepository;
+    private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
     public CalendarResponseDTO.EntryDetailResponse getEntryDetail(Long userId, String date) {
@@ -30,11 +38,108 @@ public class CalendarService {
         try {
             parsedDate = LocalDate.parse(date); // YYYY-MM-DD
         } catch (DateTimeParseException e) {
-            throw new GeneralException(CommonErrorStatus._BAD_REQUEST); // COMMON400
+            throw new GeneralException(CalendarErrorStatus.INVALID_DATE);
         }
 
         return calendarRepository.findByUserIdAndDate(userId, parsedDate)
                 .map(calendarConverter::toEntryDetailResponse)
                 .orElse(CalendarResponseDTO.EntryDetailResponse.empty(date));
+    }
+
+    /**
+     * ✅ Upsert 버전
+     *
+     * POST /api/calendar/entries/{date}
+     * - 엔트리 있으면 update
+     * - 엔트리 없으면 insert 후 update (자동 생성)
+     * - ootd 존재해야 함 (없으면 CALENDAR4041)
+     * - ootd.createdAt.toLocalDate() == date 여야 함 (아니면 OOTD_NOT_IN_DATE)
+     */
+    public CalendarResponseDTO.EntryDetailResponse connectOotd(Long userId, String date, Long ootdId) {
+        LocalDate parsedDate;
+        try {
+            parsedDate = LocalDate.parse(date);
+        } catch (DateTimeParseException e) {
+            throw new GeneralException(CalendarErrorStatus.INVALID_DATE);
+        }
+
+        // ✅ OOTD 존재 검증
+        OOTD ootd = ootdRepository.findById(ootdId)
+                .orElseThrow(() -> new GeneralException(CalendarErrorStatus.CALENDAR4041));
+
+        // ✅ "해당 날짜에 속하지 않은 OOTD" 검증
+        if (ootd.getCreatedAt() == null || !ootd.getCreatedAt().toLocalDate().equals(parsedDate)) {
+            throw new GeneralException(CalendarErrorStatus.OOTD_NOT_IN_DATE);
+        }
+
+        // ✅ 엔트리 없으면 자동 생성(upsert)
+        Calendar calendar = getOrCreateCalendar(userId, parsedDate);
+
+        // ✅ 대표 이미지를 OOTD로 설정
+        calendar.connectOotd(ootd);
+
+        return calendarConverter.toEntryDetailResponse(calendar);
+    }
+
+    /**
+     * DELETE /api/calendar/entries/{date}
+     * - row 삭제가 아니라 "OOTD 연결 내역 삭제" (ootd=null)
+     * - ✅ Upsert 정책에서 DELETE는 보통 멱등(idempotent) 처리:
+     *   엔트리가 없어도 200으로 "삭제됨" 응답 (프론트/테스트 편함)
+     */
+    public CalendarResponseDTO.EntryDeleteResponse disconnectOotd(Long userId, String date) {
+        LocalDate parsedDate;
+        try {
+            parsedDate = LocalDate.parse(date);
+        } catch (DateTimeParseException e) {
+            throw new GeneralException(CalendarErrorStatus.INVALID_DATE);
+        }
+
+        Calendar calendar = calendarRepository.findByUserIdAndDate(userId, parsedDate).orElse(null);
+
+        if (calendar != null) {
+            calendar.disconnectOotd();
+        }
+
+        return CalendarResponseDTO.EntryDeleteResponse.builder()
+                .date(parsedDate.toString())
+                .deleted(true)
+                .build();
+    }
+
+    /**
+     * calendars 테이블 제약(NOT NULL / uk_user_date) 때문에
+     * 엔트리 없으면 "기본값" 채워서 생성해야 함.
+     */
+    private Calendar getOrCreateCalendar(Long userId, LocalDate date) {
+        return calendarRepository.findByUserIdAndDate(userId, date)
+                .orElseGet(() -> {
+                    try {
+                        Calendar created = Calendar.builder()
+                                // FK만 잡고 싶으면 getReferenceById가 제일 가벼움
+                                .user(userRepository.getReferenceById(userId))
+                                .date(date)
+
+                                // ✅ DB에서 ootd_image_url NOT NULL 이라 빈 문자열로라도 채워야 함
+                                .ootdImageUrl("")
+
+                                // ✅ thumbnail NOT NULL (DB default가 있더라도 안전하게 세팅)
+                                .thumbnail(Thumbnail.OOTD)
+
+                                // ootdId는 연결 전이므로 null
+                                .ootd(null)
+
+                                // customImageUrl은 null 가능
+                                .customImageUrl(null)
+                                .build();
+
+                        return calendarRepository.save(created);
+
+                    } catch (DataIntegrityViolationException e) {
+                        // 동시성/중복 요청으로 uk_user_date에 걸릴 수 있음 -> 다시 조회해서 반환
+                        return calendarRepository.findByUserIdAndDate(userId, date)
+                                .orElseThrow(() -> e);
+                    }
+                });
     }
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/service/CalendarService.java
@@ -1,7 +1,16 @@
 package com.nova.yeobaek.domain.calendar.service;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.nova.yeobaek.domain.calendar.converter.CalendarConverter;
+import com.nova.yeobaek.domain.calendar.dto.response.CalendarResponseDTO;
+import com.nova.yeobaek.domain.calendar.repository.CalendarRepository;
+import com.nova.yeobaek.global.payload.exception.GeneralException;
+import com.nova.yeobaek.global.payload.status.CommonErrorStatus;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,4 +20,21 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Transactional
 public class CalendarService {
+
+    private final CalendarRepository calendarRepository;
+    private final CalendarConverter calendarConverter;
+
+    @Transactional(readOnly = true)
+    public CalendarResponseDTO.EntryDetailResponse getEntryDetail(Long userId, String date) {
+        LocalDate parsedDate;
+        try {
+            parsedDate = LocalDate.parse(date); // YYYY-MM-DD
+        } catch (DateTimeParseException e) {
+            throw new GeneralException(CommonErrorStatus._BAD_REQUEST); // COMMON400
+        }
+
+        return calendarRepository.findByUserIdAndDate(userId, parsedDate)
+                .map(calendarConverter::toEntryDetailResponse)
+                .orElse(CalendarResponseDTO.EntryDetailResponse.empty(date));
+    }
 }

--- a/src/main/java/com/nova/yeobaek/domain/calendar/status/CalendarErrorStatus.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/status/CalendarErrorStatus.java
@@ -20,9 +20,17 @@ public enum CalendarErrorStatus implements ErrorReason {
 	CALENDAR4040(HttpStatus.NOT_FOUND, "CALENDAR4040", "해당 날짜의 캘린더 기록이 존재하지 않습니다."),
 	CALENDAR4041(HttpStatus.NOT_FOUND, "CALENDAR4041", "존재하지 않는 OOTD입니다."),
 	CALENDAR4042(HttpStatus.NOT_FOUND, "CALENDAR4042", "해당 날짜의 캘린더 엔트리가 존재하지 않습니다."),
-	CALENDAR4043(HttpStatus.NOT_FOUND, "CALENDAR4043", "삭제할 커스텀 이미지가 존재하지 않습니다.");
+	CALENDAR4043(HttpStatus.NOT_FOUND, "CALENDAR4043", "삭제할 커스텀 이미지가 존재하지 않습니다."),
+
+	// 409 (중복 생성)
+	DUPLICATED_CALENDAR_CREATE(
+			HttpStatus.CONFLICT,
+			"CALENDAR4090",
+			"이미 해당 날짜의 캘린더 기록이 존재합니다."
+	);
 
 	private final HttpStatus httpStatus;
 	private final String code;
 	private final String message;
 }
+

--- a/src/main/java/com/nova/yeobaek/domain/calendar/status/CalendarErrorStatus.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/status/CalendarErrorStatus.java
@@ -11,7 +11,14 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum CalendarErrorStatus implements ErrorReason {
 
-	;
+	// 400
+	INVALID_DATE(HttpStatus.BAD_REQUEST, "COMMON400", "date 형식이 올바르지 않습니다."),
+	OOTD_NOT_IN_DATE(HttpStatus.BAD_REQUEST, "COMMON400", "해당 날짜에 속하지 않은 OOTD입니다."),
+
+	// 404
+	CALENDAR4040(HttpStatus.NOT_FOUND, "CALENDAR4040", "해당 날짜의 캘린더 기록이 존재하지 않습니다."),
+	CALENDAR4041(HttpStatus.NOT_FOUND, "CALENDAR4041", "존재하지 않는 OOTD입니다."),
+	CALENDAR4042(HttpStatus.NOT_FOUND, "CALENDAR4042", "해당 날짜의 캘린더 엔트리가 존재하지 않습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/nova/yeobaek/domain/calendar/status/CalendarErrorStatus.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/status/CalendarErrorStatus.java
@@ -14,11 +14,13 @@ public enum CalendarErrorStatus implements ErrorReason {
 	// 400
 	INVALID_DATE(HttpStatus.BAD_REQUEST, "COMMON400", "date 형식이 올바르지 않습니다."),
 	OOTD_NOT_IN_DATE(HttpStatus.BAD_REQUEST, "COMMON400", "해당 날짜에 속하지 않은 OOTD입니다."),
+	CUSTOM_IMAGE_REQUIRED(HttpStatus.BAD_REQUEST, "COMMON400", "CUSTOM 선택 시 customImageUrl이 필요합니다."),
 
 	// 404
 	CALENDAR4040(HttpStatus.NOT_FOUND, "CALENDAR4040", "해당 날짜의 캘린더 기록이 존재하지 않습니다."),
 	CALENDAR4041(HttpStatus.NOT_FOUND, "CALENDAR4041", "존재하지 않는 OOTD입니다."),
-	CALENDAR4042(HttpStatus.NOT_FOUND, "CALENDAR4042", "해당 날짜의 캘린더 엔트리가 존재하지 않습니다.");
+	CALENDAR4042(HttpStatus.NOT_FOUND, "CALENDAR4042", "해당 날짜의 캘린더 엔트리가 존재하지 않습니다."),
+	CALENDAR4043(HttpStatus.NOT_FOUND, "CALENDAR4043", "삭제할 커스텀 이미지가 존재하지 않습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update # Flyway가 DDL 담당 -> validate나 none으로 둬야 함
+      ddl-auto: validate
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate # Flyway가 DDL 담당 -> validate나 none으로 둬야 함
+      ddl-auto: update # Flyway가 DDL 담당 -> validate나 none으로 둬야 함
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 개요
- Closed #17  
- 날짜 단위 캘린더 기록에 대해 조회(GET), 생성(POST), 삭제(DELETE) API를 구현했습니다.
- 캘린더 기록은 OOTD 엔티티를 직접 수정/삭제하지 않고,  
  calendars 테이블의 row 생성/삭제를 통해 관리합니다.

---

## 구현 내용

###  로그인 후 테스트 환경 구성
- 개발자용 로그인 API를 통해 인증을 수행한 뒤 테스트를 진행했습니다.


(로그인 성공 화면)
<img width="1334" height="699" alt="image" src="https://github.com/user-attachments/assets/5876b592-4638-42e0-b993-380d20ae24d9" />
userid 5번을 postgresql에서 할당받음 
<img width="478" height="675" alt="image" src="https://github.com/user-attachments/assets/89265303-65e1-4a3c-af38-f3e7a226c084" />
예시  ootd 값 입력후  ootd id=4 할당받음 


---

###  날짜에 OOTD 연결 (POST)
- 테스트용 OOTD(id = 4)를 PostgreSQL DB에 사전 등록한 후,
- `POST /api/calendar/entries/{date}` API를 통해 날짜에 OOTD를 연결했습니다.
<img width="1336" height="501" alt="image" src="https://github.com/user-attachments/assets/c5a99bc3-1757-43d5-abc5-559ddac62fbb" />
<img width="1009" height="343" alt="image" src="https://github.com/user-attachments/assets/4d18636e-bfc0-4f80-8488-721911c58c1d" />



---

###  날짜 상세 조회 (GET)
- OOTD가 연결된 날짜를 조회하면,
  해당 OOTD 이미지 정보가 정상적으로 반환됩니다.
<img width="1331" height="436" alt="image" src="https://github.com/user-attachments/assets/152d7205-323e-4d50-82c6-f31476fc33ed" />


---

###  날짜 기록 삭제 (DELETE)
- `DELETE /api/calendar/entries/{date}` API를 통해
  특정 날짜의 캘린더 기록(row)을 삭제했습니다.
- OOTD 엔티티 자체는 삭제되지 않습니다.
<img width="1337" height="726" alt="image" src="https://github.com/user-attachments/assets/f12c7e82-f971-45a0-943d-31a7b5450260" />
삭제후 다시 조회를 하게 되면 
<img width="1309" height="403" alt="image" src="https://github.com/user-attachments/assets/72f0467d-f44f-4580-a442-953d0d9a83b4" />

null값들이 반환되게 됩니다.


---

###  커스텀 이미지 추가
POST /api/calendar/entries/{date}/custom-image API를 통해
해당 날짜의 캘린더 기록에 커스텀 이미지를 추가할 수 있습니다.
캘린더 기록(calendars row)이 존재하는 날짜에만 동작합니다.
커스텀 이미지는 OOTD 이미지와 별도로 저장됩니다.
커스텀 이미지 추가 시에도 대표 이미지(thumbnail)는 변경되지 않습니다.
<img width="654" height="368" alt="image" src="https://github.com/user-attachments/assets/91299d6f-abd4-4519-b5b1-a18bc0e3ef54" />
<img width="928" height="414" alt="image" src="https://github.com/user-attachments/assets/d688a1ee-b67c-44b4-b7ac-d6f1d198aacd" />


---
###  커스텀 이미지 삭제 
DELETE /api/calendar/entries/{date}/custom-image API를 통해
해당 날짜에 저장된 커스텀 이미지만 삭제합니다.
캘린더 기록(row)은 유지되며, OOTD 데이터에는 영향이 없습니다.
대표 이미지가 CUSTOM이었던 경우,
자동으로 OOTD로 복귀하도록 처리했습니다
<img width="1327" height="445" alt="image" src="https://github.com/user-attachments/assets/ae81d15d-58cf-4d46-847e-88e9a8c91a38" />
<img width="1329" height="431" alt="image" src="https://github.com/user-attachments/assets/cccc5e46-f4cc-4cf9-a74c-b6acb77065ac" />

---
###  대표 이미지 선택
PATCH /api/calendar/entries/{date}/thumbnail API를 통해
해당 날짜의 **대표 이미지를 선택(OOTD / CUSTOM)**할 수 있습니다.
CUSTOM을 선택하는 경우,
반드시 커스텀 이미지가 존재해야 합니다.
캘린더 기록이 존재하지 않는 날짜에는 요청이 실패합니다.
<img width="686" height="311" alt="image" src="https://github.com/user-attachments/assets/278e35df-818e-441c-9c9a-fd5fcf1a03aa" />
<img width="909" height="349" alt="image" src="https://github.com/user-attachments/assets/4db24700-684d-4cf4-aa1e-e361a9e461c0" />
<img width="457" height="162" alt="image" src="https://github.com/user-attachments/assets/9eaff710-3dd0-4edc-a851-b67601f2cb7c" />
<img width="632" height="265" alt="image" src="https://github.com/user-attachments/assets/bb6627f2-9d99-44b0-9606-a92ca1d135e0" />
<img width="335" height="150" alt="image" src="https://github.com/user-attachments/assets/d2b5a086-3bd5-4a32-9430-648a6bf81c9a" />
<img width="496" height="129" alt="image" src="https://github.com/user-attachments/assets/9fff525b-ddf7-48b1-82bf-9e6fe014d55e" />


---

## 설계 정책
- 캘린더는 **하루 1개의 기록만 유지**하도록 설계되어 있습니다.
- 기존 기록이 존재하는 경우,
  **삭제(DELETE) 후 재생성(POST)** 방식으로 처리합니다.
- 날짜 상세 조회 API는
  기록이 없는 날짜에 대해 **200 OK + 빈 result**를 반환합니다.

---

## PR 유형
- [x] 새로운 기능 추가

---

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다. (Swagger 기반 로컬 테스트)

---

📣 **To Reviewers**
- 날짜 캘린더 기록은 OOTD 연결/해제 개념이 아닌  
  **캘린더 기록(row)의 생성/삭제 구조**로 동작합니다.
- OOTD 엔티티 자체는 삭제하지 않고,  
  캘린더 도메인에서만 관계를 관리합니다.

- Reviewers : 팀원 지정
- Labels : Feat
