### PR TITLE
[Feat] #23 OOTD 수정 및 삭제 API 구현 (캘린더 연동은 추후 예정)

### DIFF
--- a/src/main/java/com/nova/yeobaek/domain/ootd/controller/OOTDController.java
+++ b/src/main/java/com/nova/yeobaek/domain/ootd/controller/OOTDController.java
@@ -74,4 +74,36 @@ public class OOTDController implements OOTDControllerDocs {
 
         return CommonResponse.onSuccess(response);
     }
+
+    /** OOTD 수정 */
+    @Override
+    @PatchMapping("/{ootdId}")
+    public CommonResponse<Void> updateOOTD(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long ootdId,
+            @Valid @RequestBody OOTDRequestDTO.Update requestDTO
+    ) {
+        ootdService.updateOOTD(
+                userDetails.getUser(),
+                ootdId,
+                requestDTO
+        );
+
+        return CommonResponse.onSuccess(null);
+    }
+
+    /** OOTD 삭제 */
+    @Override
+    @DeleteMapping("/{ootdId}")
+    public CommonResponse<Void> deleteOOTD(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long ootdId
+    ) {
+        ootdService.deleteOOTD(
+                userDetails.getUser(),
+                ootdId
+        );
+
+        return CommonResponse.onSuccess(null);
+    }
 }

--- a/src/main/java/com/nova/yeobaek/domain/ootd/controller/OOTDController.java
+++ b/src/main/java/com/nova/yeobaek/domain/ootd/controller/OOTDController.java
@@ -55,13 +55,7 @@ public class OOTDController implements OOTDControllerDocs {
     ) {
         OOTDListResponse response = ootdService.getOOTDList(
                 userDetails.getUser(),
-                condition.keyword(),
-                condition.favorite(),
-                condition.resolvedTpoIds(),
-                condition.resolvedStyleIds(),
-                condition.resolvedSort(),
-                condition.cursor(),
-                condition.resolvedLimit()
+                condition
         );
 
         return CommonResponse.onSuccess(response);

--- a/src/main/java/com/nova/yeobaek/domain/ootd/controller/OOTDController.java
+++ b/src/main/java/com/nova/yeobaek/domain/ootd/controller/OOTDController.java
@@ -53,11 +53,16 @@ public class OOTDController implements OOTDControllerDocs {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @ParameterObject @Valid @ModelAttribute OOTDRequestDTO.SearchCondition condition
     ) {
-        OOTDListResponse response =
-                ootdService.getOOTDList(
-                        userDetails.getUser(),
-                        condition
-                );
+        OOTDListResponse response = ootdService.getOOTDList(
+                userDetails.getUser(),
+                condition.keyword(),
+                condition.favorite(),
+                condition.resolvedTpoIds(),
+                condition.resolvedStyleIds(),
+                condition.resolvedSort(),
+                condition.cursor(),
+                condition.resolvedLimit()
+        );
 
         return CommonResponse.onSuccess(response);
     }

--- a/src/main/java/com/nova/yeobaek/domain/ootd/controller/docs/OOTDControllerDocs.java
+++ b/src/main/java/com/nova/yeobaek/domain/ootd/controller/docs/OOTDControllerDocs.java
@@ -152,6 +152,11 @@ public interface OOTDControllerDocs {
             content = @Content(schema = @Schema(implementation = CommonResponse.class))
     )
     @ApiResponse(
+            responseCode = "400",
+            description = "유효하지 않은 요청 (이미지 배경 색상, 아이템 ID 중복 등)",
+            content = @Content(mediaType = "application/json")
+    )
+    @ApiResponse(
             responseCode = "404",
             description = "존재하지 않거나 접근할 수 없는 OOTD",
             content = @Content(mediaType = "application/json")
@@ -167,8 +172,8 @@ public interface OOTDControllerDocs {
             summary = "OOTD 삭제",
             description = """
             로그인 사용자의 OOTD를 삭제합니다.
-               OOTD를 하드딜리트합니다.
-               OOTD와 연결된 아이템 매핑(OOTDItem)도 함께 삭제됩니다.
+            OOTD를 하드딜리트합니다.
+            OOTD와 연결된 아이템 매핑(OOTDItem)도 함께 삭제됩니다.
 
             - 본인 OOTD만 삭제할 수 있습니다.
             """

--- a/src/main/java/com/nova/yeobaek/domain/ootd/controller/docs/OOTDControllerDocs.java
+++ b/src/main/java/com/nova/yeobaek/domain/ootd/controller/docs/OOTDControllerDocs.java
@@ -167,8 +167,8 @@ public interface OOTDControllerDocs {
             summary = "OOTD 삭제",
             description = """
             로그인 사용자의 OOTD를 삭제합니다.
-            실제 데이터는 삭제되지 않으며,
-            status 값을 변경하는 논리 삭제 방식으로 처리됩니다.
+               OOTD를 하드딜리트합니다.
+               OOTD와 연결된 아이템 매핑(OOTDItem)도 함께 삭제됩니다.
 
             - 본인 OOTD만 삭제할 수 있습니다.
             """

--- a/src/main/java/com/nova/yeobaek/domain/ootd/controller/docs/OOTDControllerDocs.java
+++ b/src/main/java/com/nova/yeobaek/domain/ootd/controller/docs/OOTDControllerDocs.java
@@ -134,4 +134,57 @@ public interface OOTDControllerDocs {
             @PathVariable Long ootdId
     );
 
+    /** OOTD 수정 */
+    @Operation(
+            summary = "OOTD 수정",
+            description = """
+            로그인 사용자의 OOTD 정보를 수정합니다.
+            PATCH 방식으로 부분 수정이 가능하며,
+            전달되지 않은 필드는 기존 값을 유지합니다.
+
+            - 아이템 목록이 전달될 경우 전체 교체 방식으로 수정됩니다.
+            - 본인 OOTD만 수정할 수 있습니다.
+            """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "OOTD 수정 성공",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "존재하지 않거나 접근할 수 없는 OOTD",
+            content = @Content(mediaType = "application/json")
+    )
+    CommonResponse<Void> updateOOTD(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long ootdId,
+            @Valid @RequestBody OOTDRequestDTO.Update requestDTO
+    );
+
+    /** OOTD 삭제 */
+    @Operation(
+            summary = "OOTD 삭제",
+            description = """
+            로그인 사용자의 OOTD를 삭제합니다.
+            실제 데이터는 삭제되지 않으며,
+            status 값을 변경하는 논리 삭제 방식으로 처리됩니다.
+
+            - 본인 OOTD만 삭제할 수 있습니다.
+            """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "OOTD 삭제 성공",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class))
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "존재하지 않거나 접근할 수 없는 OOTD",
+            content = @Content(mediaType = "application/json")
+    )
+    CommonResponse<Void> deleteOOTD(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long ootdId
+    );
 }

--- a/src/main/java/com/nova/yeobaek/domain/ootd/domain/OOTD.java
+++ b/src/main/java/com/nova/yeobaek/domain/ootd/domain/OOTD.java
@@ -88,4 +88,45 @@ public class OOTD extends BaseEntity {
 	@OneToMany(mappedBy = "ootd", cascade = CascadeType.ALL)
 	@Builder.Default
 	private List<OOTDItem> ootdItemList = new ArrayList<>();
+
+	/** OOTD 수정 */
+    // 이름 수정
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    // 메모 수정
+    public void updateMemo(String memo) {
+        this.memo = memo;
+    }
+
+    //즐겨찾기 수정
+    public void updateFavorite(boolean favorite) {
+        this.favorite = favorite;
+    }
+
+    //TPO 수정
+    public void updateTpo(TPO tpo) {
+        this.tpo = tpo;
+    }
+
+    //Style 수정
+    public void updateStyle(Style style) {
+        this.style = style;
+    }
+
+    //이미지 배경 색상 수정
+    public void updateImageBackground(ImageBackgroundColor backgroundColor) {
+        this.imageBackgroundColor = backgroundColor;
+    }
+
+    //아이템 변경 횟수 증가
+    public void increaseChangeItemCount() {
+        this.changeItemCount++;
+    }
+
+    //OOTD 상태 변경
+    public void changeStatus(OOTDStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/nova/yeobaek/domain/ootd/dto/request/OOTDRequestDTO.java
+++ b/src/main/java/com/nova/yeobaek/domain/ootd/dto/request/OOTDRequestDTO.java
@@ -103,4 +103,31 @@ public class OOTDRequestDTO {
             return (styleId == null || styleId.isEmpty()) ? null : styleId;
         }
     }
+
+    /** OOTD 수정 요청 */
+    public record Update(
+
+            @Schema(description = "OOTD 이름")
+            String name,
+
+            @Schema(description = "OOTD 메모")
+            String memo,
+
+            @Schema(description = "즐겨찾기 여부")
+            Boolean favorite,
+
+            @Schema(description = "TPO ID")
+            Long tpoId,
+
+            @Schema(description = "Style ID")
+            Long styleId,
+
+            @Schema(description = "이미지 배경 색상")
+            String imageBackground,
+
+            @Schema(description = "OOTD 아이템 목록 (전체 교체)")
+            @Valid
+            List<Item> items
+    ) {
+    }
 }

--- a/src/main/java/com/nova/yeobaek/domain/ootd/repository/ootdItem/OOTDItemRepository.java
+++ b/src/main/java/com/nova/yeobaek/domain/ootd/repository/ootdItem/OOTDItemRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.nova.yeobaek.domain.ootd.domain.mapping.OOTDItem;
 
 public interface OOTDItemRepository extends JpaRepository<OOTDItem, Long>, OOTDItemRepositoryCustom {
+    void deleteAllByOotd_Id(Long ootdId);
 }

--- a/src/main/java/com/nova/yeobaek/domain/ootd/service/OOTDService.java
+++ b/src/main/java/com/nova/yeobaek/domain/ootd/service/OOTDService.java
@@ -121,31 +121,43 @@ public class OOTDService {
 
     /** OOTD 수정 */
     @Transactional
+    //OOTD 수정 유스케이스
     public void updateOOTD(
             User user,
             Long ootdId,
             OOTDRequestDTO.Update requestDTO
     ) {
-        // 1. OOTD 조회, 권한 검증
-        OOTD ootd = ootdRepository.findById(ootdId)
+        OOTD ootd = getAuthorizedOOTD(user, ootdId);
+
+        updateBasicFields(ootd, requestDTO);
+        updateRelations(ootd, requestDTO);
+        updateImageBackgroundIfNeeded(ootd, requestDTO);
+        updateItemsIfNeeded(ootd, requestDTO);
+    }
+
+    //수정,삭제 OOTD 조회 및 권한 검증
+    private OOTD getAuthorizedOOTD(User user, Long ootdId) {
+        return ootdRepository.findById(ootdId)
                 .filter(o -> o.getStatus() == OOTDStatus.NORMAL)
                 .filter(o -> o.getUser().getId().equals(user.getId()))
                 .orElseThrow(() -> new OOTDException(OOTDErrorStatus.OOTD_NOT_FOUND));
+    }
 
-        // 2. 기본 필드 수정 (null이면 스킵)
+    //OOTD 기본 필드 수정
+    private void updateBasicFields(OOTD ootd, OOTDRequestDTO.Update requestDTO) {
         if (requestDTO.name() != null) {
             ootd.updateName(requestDTO.name());
         }
-
         if (requestDTO.memo() != null) {
             ootd.updateMemo(requestDTO.memo());
         }
-
         if (requestDTO.favorite() != null) {
             ootd.updateFavorite(requestDTO.favorite());
         }
+    }
 
-        // 3. TPO / Style 수정
+    //OOTD 연관 엔티티 수정
+    private void updateRelations(OOTD ootd, OOTDRequestDTO.Update requestDTO) {
         if (requestDTO.tpoId() != null) {
             TPO tpo = findTpo(requestDTO.tpoId());
             ootd.updateTpo(tpo);
@@ -154,44 +166,42 @@ public class OOTDService {
             Style style = findStyle(requestDTO.styleId());
             ootd.updateStyle(style);
         }
+    }
 
-        // 4. 이미지 배경 색상 수정
+    //OOTD 이미지 배경색상 수정
+    private void updateImageBackgroundIfNeeded(OOTD ootd, OOTDRequestDTO.Update requestDTO) {
         if (requestDTO.imageBackground() != null) {
             ImageBackgroundColor backgroundColor =
                     parseBackground(requestDTO.imageBackground());
             ootd.updateImageBackground(backgroundColor);
         }
+    }
 
-        // 5. 아이템 수정 (전체교체방식)
-        if (requestDTO.items() != null) {
-
-            // 기존 아이템 스냅샷 (캘린더/착용횟수 diff 계산용 - TODO:추후 사용)
-            List<OOTDItem> beforeItems = ootd.getOotdItemList();
-
-            // 기존 아이템 매핑 삭제
-            ootdItemRepository.deleteAllByOotd_Id(ootd.getId());
-
-            // 아이템 검증
-            List<Long> itemIds = requestDTO.items().stream()
-                    .map(OOTDRequestDTO.Item::fashionItemId)
-                    .toList();
-
-            validateDuplicatedItemIds(itemIds);
-            Map<Long, Item> itemMap = loadItemsOrThrow(itemIds);
-
-            // 새 아이템 저장
-            List<OOTDItem> newItems =
-                    OOTDConverter.toOOTDItems(requestDTO.items(), ootd, itemMap);
-
-            ootdItemRepository.saveAll(newItems);
-
-            // 아이템 변경 횟수 카운트
-            ootd.increaseChangeItemCount();
-
-            // TODO(#calendar): 해당 OOTD가 기록된 캘린더 엔트리들의 ootdImageUrl 최신화
-            // TODO(#item): 캘린더 기록 수 기준으로 아이템 착용 횟수 diff 반영
-            // beforeItems 와 newItems 비교하여 계산 예정
+    //OOTD 아이템 구성 수정
+    private void updateItemsIfNeeded(OOTD ootd, OOTDRequestDTO.Update requestDTO) {
+        if (requestDTO.items() == null) {
+            return;
         }
+
+        List<OOTDItem> beforeItems = ootd.getOotdItemList();
+
+        ootdItemRepository.deleteAllByOotd_Id(ootd.getId());
+
+        List<Long> itemIds = requestDTO.items().stream()
+                .map(OOTDRequestDTO.Item::fashionItemId)
+                .toList();
+
+        validateDuplicatedItemIds(itemIds);
+        Map<Long, Item> itemMap = loadItemsOrThrow(itemIds);
+
+        List<OOTDItem> newItems =
+                OOTDConverter.toOOTDItems(requestDTO.items(), ootd, itemMap);
+
+        ootdItemRepository.saveAll(newItems);
+        ootd.increaseChangeItemCount();
+
+        // TODO(#calendar): 해당 OOTD가 기록된 캘린더 엔트리들의 ootdImageUrl 최신화
+        // TODO(#item): 캘린더 기록 수 기준으로 아이템 착용 횟수 diff 반영
     }
 
     /** OOTD 삭제 (하드 딜리트) */

--- a/src/main/java/com/nova/yeobaek/domain/ootd/service/OOTDService.java
+++ b/src/main/java/com/nova/yeobaek/domain/ootd/service/OOTDService.java
@@ -45,6 +45,7 @@ public class OOTDService {
     private final TPORepository tpoRepository;
     private final ItemRepository itemRepository;
 
+    /** OOTD 등록 */
     @Transactional
     public Long createOOTD(User user, OOTDRequestDTO.Create requestDTO) {
         Style style = findStyle(requestDTO.styleId());
@@ -116,6 +117,104 @@ public class OOTDService {
                 itemMap
         );
         ootdItemRepository.saveAll(ootdItems);
+    }
+
+    /** OOTD 수정 */
+    @Transactional
+    public void updateOOTD(
+            User user,
+            Long ootdId,
+            OOTDRequestDTO.Update requestDTO
+    ) {
+        // 1. OOTD 조회, 권한 검증
+        OOTD ootd = ootdRepository.findById(ootdId)
+                .filter(o -> o.getStatus() == OOTDStatus.NORMAL)
+                .filter(o -> o.getUser().getId().equals(user.getId()))
+                .orElseThrow(() -> new OOTDException(OOTDErrorStatus.OOTD_NOT_FOUND));
+
+        // 2. 기본 필드 수정 (null이면 스킵)
+        if (requestDTO.name() != null) {
+            ootd.updateName(requestDTO.name());
+        }
+
+        if (requestDTO.memo() != null) {
+            ootd.updateMemo(requestDTO.memo());
+        }
+
+        if (requestDTO.favorite() != null) {
+            ootd.updateFavorite(requestDTO.favorite());
+        }
+
+        // 3. TPO / Style 수정
+        if (requestDTO.tpoId() != null) {
+            TPO tpo = findTpo(requestDTO.tpoId());
+            ootd.updateTpo(tpo);
+        }
+        if (requestDTO.styleId() != null) {
+            Style style = findStyle(requestDTO.styleId());
+            ootd.updateStyle(style);
+        }
+
+        // 4. 이미지 배경 색상 수정
+        if (requestDTO.imageBackground() != null) {
+            ImageBackgroundColor backgroundColor =
+                    parseBackground(requestDTO.imageBackground());
+            ootd.updateImageBackground(backgroundColor);
+        }
+
+        // 5. 아이템 수정 (전체교체방식)
+        if (requestDTO.items() != null) {
+
+            // 기존아이템 삭제
+            ootdItemRepository.deleteAllByOotd_Id(ootd.getId());
+
+            // 아이템 검증
+            List<Long> itemIds = requestDTO.items().stream()
+                    .map(OOTDRequestDTO.Item::fashionItemId)
+                    .toList();
+
+            validateDuplicatedItemIds(itemIds);
+            Map<Long, Item> itemMap = loadItemsOrThrow(itemIds);
+
+            // 새 아이템 저장
+            List<OOTDItem> newItems =
+                    OOTDConverter.toOOTDItems(requestDTO.items(), ootd, itemMap);
+
+            ootdItemRepository.saveAll(newItems);
+
+            // 아이템 변경 횟수 카운트
+            ootd.increaseChangeItemCount();
+        }
+    }
+
+    /** OOTD 삭제 */
+    @Transactional
+    public void deleteOOTD(User user, Long ootdId) {
+
+        OOTD ootd = ootdRepository.findById(ootdId)
+                .filter(o -> o.getStatus() == OOTDStatus.NORMAL)
+                .filter(o -> o.getUser().getId().equals(user.getId()))
+                .orElseThrow(() -> new OOTDException(OOTDErrorStatus.OOTD_NOT_FOUND));
+
+        ootd.changeStatus(OOTDStatus.ABNORMAL);
+    }
+
+    /** OOTD 목록조회 */
+    @Transactional(readOnly = true)
+    public OOTDListResponse getOOTDList(
+            User user,
+            OOTDRequestDTO.SearchCondition condition
+    ) {
+        return getOOTDList(
+                user,
+                condition.keyword(),
+                condition.favorite(),
+                condition.resolvedTpoIds(),
+                condition.resolvedStyleIds(),
+                condition.resolvedSort(),
+                condition.cursor(),
+                condition.resolvedLimit()
+        );
     }
 
     /** OOTD 목록조회 */

--- a/src/main/java/com/nova/yeobaek/domain/ootd/service/OOTDService.java
+++ b/src/main/java/com/nova/yeobaek/domain/ootd/service/OOTDService.java
@@ -165,7 +165,10 @@ public class OOTDService {
         // 5. 아이템 수정 (전체교체방식)
         if (requestDTO.items() != null) {
 
-            // 기존아이템 삭제
+            // 기존 아이템 스냅샷 (캘린더/착용횟수 diff 계산용 - TODO:추후 사용)
+            List<OOTDItem> beforeItems = ootd.getOotdItemList();
+
+            // 기존 아이템 매핑 삭제
             ootdItemRepository.deleteAllByOotd_Id(ootd.getId());
 
             // 아이템 검증
@@ -184,19 +187,31 @@ public class OOTDService {
 
             // 아이템 변경 횟수 카운트
             ootd.increaseChangeItemCount();
+
+            // TODO(#calendar): 해당 OOTD가 기록된 캘린더 엔트리들의 ootdImageUrl 최신화
+            // TODO(#item): 캘린더 기록 수 기준으로 아이템 착용 횟수 diff 반영
+            // beforeItems 와 newItems 비교하여 계산 예정
         }
     }
 
-    /** OOTD 삭제 */
+    /** OOTD 삭제 (하드 딜리트) */
     @Transactional
     public void deleteOOTD(User user, Long ootdId) {
 
         OOTD ootd = ootdRepository.findById(ootdId)
-                .filter(o -> o.getStatus() == OOTDStatus.NORMAL)
                 .filter(o -> o.getUser().getId().equals(user.getId()))
                 .orElseThrow(() -> new OOTDException(OOTDErrorStatus.OOTD_NOT_FOUND));
 
-        ootd.changeStatus(OOTDStatus.ABNORMAL);
+        // 1. OOTD에 연결된 아이템 매핑 삭제
+        ootdItemRepository.deleteAllByOotd_Id(ootd.getId());
+
+        // 2. TODO: 캘린더 파트 머지 후 연동
+        // TODO(#calendar): 해당 OOTD가 기록된 모든 캘린더 엔트리 삭제
+        // TODO(#calendar): 캘린더 삭제에 따른 아이템 사용 횟수 차감
+        // 아직 캘린더 도메인이 푸쉬되지 않아서 제가 건드릴 수 없어서 일단 투두로 뒀습니다!!
+
+        // 3. OOTD 하드딜리트
+        ootdRepository.delete(ootd);
     }
 
     /** OOTD 목록조회 */


### PR DESCRIPTION
## 개요
- closed #23

OOTD 도메인의 수정(PATCH) 및 삭제(DELETE) API를 구현했습니다.  
OOTD 수정 시 아이템 구성 변경을 고려한 구조로 설계했으며,  
삭제는 하드 딜리트 방식으로 처리했습니다.

캘린더 및 아이템 착용 횟수와의 연동은 도메인 책임 분리를 위해  
TODO 형태로 명시하고, 추후 연동을 전제로 구조를 잡았습니다.

---

## 변경 사항 요약

###  OOTD 수정 (PATCH /api/ootds/{ootdId})
- OOTD 기본 정보 수정 지원
  - 이름, 메모, 즐겨찾기, TPO, Style, 배경색
- OOTD 아이템 구성 전체 교체 방식 유지
- 아이템 변경 전/후 스냅샷을 확보하여
  - 추후 캘린더 이미지 갱신
  - 아이템 착용 횟수 diff 계산이 가능하도록 설계
- 캘린더/아이템 도메인 연동은 TODO로 분리

###  OOTD 삭제 (DELETE /api/ootds/{ootdId})
- OOTD 하드 딜리트 방식 적용
- OOTD에 포함된 OOTDItem 엔티티 함께 삭제
- 캘린더에 기록된 OOTD 엔트리 삭제 및
  아이템 착용 횟수 차감 로직은
  → 캘린더 도메인 merge 이후 연동 예정 (TODO 명시)

---

## 캘린더 연동 관련 설계 메모
- OOTD 수정 시:
  - 과거 캘린더 기록의 OOTD 이미지 최신화 필요
  - 아이템 변경에 따른 착용 횟수 재계산 필요
  - (캘린더 연동 후 추후 구현 예정)
- OOTD 삭제 시:
  - 해당 OOTD가 기록된 모든 캘린더 엔트리 삭제
  - 삭제된 기록 수만큼 아이템 착용 횟수 차감
  - (캘린더 연동 후 추후 구현 예정)

- 현재 PR에서는
  - 도메인 책임 분리를 위해 직접 구현하지 않고
  - TODO 주석으로 연동 지점을 남김

---

## 스웨거 / 테스트 확인
<img width="1065" height="576" alt="스크린샷 2026-01-19 오후 3 55 29" src="https://github.com/user-attachments/assets/6ce655d9-4027-4d9a-a732-7da5463dd43e" />
→  수정 및 삭제 테스트를 위한 OOTD 40 을 추가
<img width="1058" height="529" alt="스크린샷 2026-01-19 오후 3 56 35" src="https://github.com/user-attachments/assets/b751a968-2fca-4462-89ea-500f6004a17a" />
→  수정 요청 성공
<img width="1055" height="714" alt="스크린샷 2026-01-19 오후 3 56 52" src="https://github.com/user-attachments/assets/d3b53930-879a-48f7-8a84-031099f1438b" />
→  수정 후 OOTD40 상세조회
<img width="1071" height="683" alt="스크린샷 2026-01-19 오후 3 57 09" src="https://github.com/user-attachments/assets/8c2557cc-5730-466c-8340-155c16380d2d" />
→  OOTD40 삭제 요청 성공
<img width="1062" height="694" alt="스크린샷 2026-01-19 오후 3 57 37" src="https://github.com/user-attachments/assets/33d5452f-b047-4359-ad51-788514302796" />
→  OOTD 삭제 후 상세조회

---

## PR 유형
- [x] 새로운 기능 추가

---

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] Swagger 및 로컬 테스트를 완료했습니다.

---

📣 **To Reviewers**
- OOTD 삭제 정책(하드 딜리트) 및
  캘린더 연동을 TODO로 분리한 구조 위주로 봐주시면 감사하겠습니다.
- 캘린더 연동시 동작 설명 (캘린더 도메인 develop브랜치에 머지 후 구현 예정)
→  오오티디 수정 시 캘린더에 해당 오오티디 기록의 사진도 최신화 되도록 구현 예정.
→  오오티디 삭제 시 캘린더에 해당 오오티디의 기록 모두 삭제(3개월 이내 기록만), 캘린더에 기록되었던 만큼 오오티디에 포함되었던 아이템의 착용횟수를 차감시킴.

- Reviewers : @Jinho-5 
- Labels : Feat