### PR TITLE
[Feat] #25 OOTD 즐겨찾기 설정/해제 API 구현

### DIFF
--- a/src/main/java/com/nova/yeobaek/domain/ootd/controller/OOTDController.java
+++ b/src/main/java/com/nova/yeobaek/domain/ootd/controller/OOTDController.java
@@ -46,6 +46,16 @@ public class OOTDController implements OOTDControllerDocs {
         return CommonResponse.onCreated(new CreateOOTDResponse(ootdId));
     }
 
+    /** OOTD 즐겨찾기 */
+    @PatchMapping("/{ootdId}/favorite")
+    public CommonResponse<Void> toggleFavorite(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long ootdId
+    ) {
+        ootdService.toggleFavorite(userDetails.getUser(), ootdId);
+        return CommonResponse.onSuccess(null);
+    }
+
     /** OOTD 목록 조회 */
     @Override
     @GetMapping

--- a/src/main/java/com/nova/yeobaek/domain/ootd/controller/docs/OOTDControllerDocs.java
+++ b/src/main/java/com/nova/yeobaek/domain/ootd/controller/docs/OOTDControllerDocs.java
@@ -118,6 +118,22 @@ public interface OOTDControllerDocs {
             OOTDRequestDTO.SearchCondition condition
     );
 
+    /** OOTD 즐겨찾기 */
+    @Operation(
+            summary = "OOTD 즐겨찾기 설정/해제",
+            description = """
+        로그인 사용자의 OOTD 즐겨찾기 상태를 토글합니다.
+        - 즐겨찾기 → 해제
+        - 해제 → 즐겨찾기
+        """
+    )
+    @ApiResponse(responseCode = "200", description = "즐겨찾기 상태 변경 성공")
+    @ApiResponse(responseCode = "404", description = "존재하지 않거나 접근할 수 없는 OOTD")
+    CommonResponse<Void> toggleFavorite(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long ootdId
+    );
+
     /** OOTD 상세 조회 */
     @Operation(
             summary = "OOTD 상세 조회",

--- a/src/main/java/com/nova/yeobaek/domain/ootd/domain/OOTD.java
+++ b/src/main/java/com/nova/yeobaek/domain/ootd/domain/OOTD.java
@@ -129,4 +129,9 @@ public class OOTD extends BaseEntity {
     public void changeStatus(OOTDStatus status) {
         this.status = status;
     }
+
+	//OOTD 즐겨찾기
+	public void toggleFavorite() {
+		this.favorite = !this.favorite;
+	}
 }

--- a/src/main/java/com/nova/yeobaek/domain/ootd/service/OOTDService.java
+++ b/src/main/java/com/nova/yeobaek/domain/ootd/service/OOTDService.java
@@ -119,6 +119,13 @@ public class OOTDService {
         ootdItemRepository.saveAll(ootdItems);
     }
 
+    /** OOTD 즐겨찾기 */
+    @Transactional
+    public void toggleFavorite(User user, Long ootdId) {
+        OOTD ootd = getAuthorizedOOTD(user, ootdId);
+        ootd.toggleFavorite();
+    }
+
     /** OOTD 수정 */
     @Transactional
     //OOTD 수정 유스케이스


### PR DESCRIPTION
## 개요
- closed #25
- OOTD 즐겨찾기 설정/해제 기능을 위한 API를 구현했습니다.
- 사용자가 본인의 OOTD에 대해서만 즐겨찾기 상태를 변경할 수 있도록 권한 검증을 포함했습니다.
- 즐겨찾기 상태 변경 로직을 도메인(OOTD 엔티티) 책임으로 분리하여 구현했습니다.
<img width="1041" height="747" alt="스크린샷 2026-01-19 오후 11 42 59" src="https://github.com/user-attachments/assets/4fd23506-adc4-4f02-b5ec-7919e3834c8c" />
→  OOTD 30: Favorite(false)
<img width="1050" height="540" alt="스크린샷 2026-01-19 오후 11 43 16" src="https://github.com/user-attachments/assets/eabed610-16e9-4023-bd24-84fa0e9844fd" />
→  OOTD 30에 대해 즐겨찾기 설정 실행
<img width="1046" height="733" alt="스크린샷 2026-01-19 오후 11 43 41" src="https://github.com/user-attachments/assets/c89a826a-acba-49fd-ad3d-9f92f3102c92" />
→  OOTD 30: Favorite(true)
<img width="1055" height="549" alt="스크린샷 2026-01-19 오후 11 44 02" src="https://github.com/user-attachments/assets/05515eaf-174c-46cc-80f9-e78e447f531a" />
→   OOTD 30에 대해 즐겨찾기 설정 실행
<img width="1049" height="716" alt="스크린샷 2026-01-19 오후 11 44 18" src="https://github.com/user-attachments/assets/c682e3fc-fdf6-4b33-8034-ce3f95beb0ac" />
→  OOTD 30: Favorite(false)

<!-- Resolves: #25 -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 로컬 빌드 및 Swagger를 통해 정상 동작을 확인했습니다.

📣 **To Reviewers**
---
- 즐겨찾기 API 설정입니다.
- 이 다음은 OOTD 삭제/수정을 캘린더 및 통계 쪽 연결할 예정입니다.

- Reviewers : @Jinho-5 
- Labels : Feature