### PR TITLE
[Feat]#34 Stats 아이템 frequent/inactive 통계 API 구현

### DIFF
--- a/src/main/java/com/nova/yeobaek/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/nova/yeobaek/domain/item/repository/ItemRepository.java
@@ -1,8 +1,9 @@
 package com.nova.yeobaek.domain.item.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.List;
 import com.nova.yeobaek.domain.item.domain.Item;
 
 public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositoryCustom {
+    List<Item> findAllByUser_Id(Long userId);
 }

--- a/src/main/java/com/nova/yeobaek/domain/stats/controller/StatsController.java
+++ b/src/main/java/com/nova/yeobaek/domain/stats/controller/StatsController.java
@@ -29,18 +29,6 @@ public class StatsController implements StatsControllerDocs {
             @RequestParam(defaultValue = "3") int inactivePreviewLimit,
             @RequestParam(defaultValue = "30") int inactiveDays
     ) {
-        // ✅ 디버그용 (지금 문제는 여기서 userId가 1로 들어오냐가 핵심)
-        System.out.println("[StatsController] user = " + user);
-        System.out.println("[StatsController] userId = " + (user == null ? null : user.getId()));
-        System.out.println("[StatsController] frequentLimit=" + frequentLimit
-                + ", inactivePreviewLimit=" + inactivePreviewLimit
-                + ", inactiveDays=" + inactiveDays);
-
-        // ✅ user가 null이면 조용히 빈 배열 만들지 말고 바로 원인 드러내기
-        if (user == null || user.getId() == null) {
-            throw new IllegalStateException("AuthenticationPrincipal(user)가 null 입니다. (principal 매핑 확인 필요)");
-        }
-
         return CommonResponse.onSuccess(
                 statsService.getItemsSummary(
                         user.getId(),

--- a/src/main/java/com/nova/yeobaek/domain/stats/controller/StatsController.java
+++ b/src/main/java/com/nova/yeobaek/domain/stats/controller/StatsController.java
@@ -1,0 +1,53 @@
+package com.nova.yeobaek.domain.stats.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nova.yeobaek.domain.stats.controller.docs.StatsControllerDocs;
+import com.nova.yeobaek.domain.stats.dto.response.StatsResponseDTO;
+import com.nova.yeobaek.domain.stats.service.StatsService;
+import com.nova.yeobaek.domain.user.domain.User;
+import com.nova.yeobaek.global.payload.response.CommonResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/stats")
+public class StatsController implements StatsControllerDocs {
+
+    private final StatsService statsService;
+
+    @Override
+    @GetMapping("/items")
+    public CommonResponse<StatsResponseDTO.ItemsSummaryResponse> getItemsSummary(
+            @AuthenticationPrincipal(expression = "user") User user,
+            @RequestParam(defaultValue = "10") int frequentLimit,
+            @RequestParam(defaultValue = "3") int inactivePreviewLimit,
+            @RequestParam(defaultValue = "30") int inactiveDays
+    ) {
+        // ✅ 디버그용 (지금 문제는 여기서 userId가 1로 들어오냐가 핵심)
+        System.out.println("[StatsController] user = " + user);
+        System.out.println("[StatsController] userId = " + (user == null ? null : user.getId()));
+        System.out.println("[StatsController] frequentLimit=" + frequentLimit
+                + ", inactivePreviewLimit=" + inactivePreviewLimit
+                + ", inactiveDays=" + inactiveDays);
+
+        // ✅ user가 null이면 조용히 빈 배열 만들지 말고 바로 원인 드러내기
+        if (user == null || user.getId() == null) {
+            throw new IllegalStateException("AuthenticationPrincipal(user)가 null 입니다. (principal 매핑 확인 필요)");
+        }
+
+        return CommonResponse.onSuccess(
+                statsService.getItemsSummary(
+                        user.getId(),
+                        frequentLimit,
+                        inactivePreviewLimit,
+                        inactiveDays
+                )
+        );
+    }
+}

--- a/src/main/java/com/nova/yeobaek/domain/stats/controller/docs/StatsControllerDocs.java
+++ b/src/main/java/com/nova/yeobaek/domain/stats/controller/docs/StatsControllerDocs.java
@@ -23,7 +23,7 @@ public interface StatsControllerDocs {
                     """
     )
     CommonResponse<StatsResponseDTO.ItemsSummaryResponse> getItemsSummary(
-            @AuthenticationPrincipal User user,
+            @AuthenticationPrincipal(expression = "user") User user,
 
             @Parameter(description = "자주 착용한 아이템 개수", example = "10")
             @RequestParam(defaultValue = "10") int frequentLimit,

--- a/src/main/java/com/nova/yeobaek/domain/stats/controller/docs/StatsControllerDocs.java
+++ b/src/main/java/com/nova/yeobaek/domain/stats/controller/docs/StatsControllerDocs.java
@@ -1,0 +1,37 @@
+package com.nova.yeobaek.domain.stats.controller.docs;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.nova.yeobaek.domain.stats.dto.response.StatsResponseDTO;
+import com.nova.yeobaek.domain.user.domain.User;
+import com.nova.yeobaek.global.payload.response.CommonResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Stats", description = "통계 API")
+public interface StatsControllerDocs {
+
+    @Operation(
+            summary = "아이템 착용 통계 요약 조회",
+            description = """
+                    - 자주 착용한 아이템 목록
+                    - 최근 착용하지 않은 아이템(미착용 포함)
+                    - 미리보기 외 나머지 개수 제공
+                    """
+    )
+    CommonResponse<StatsResponseDTO.ItemsSummaryResponse> getItemsSummary(
+            @AuthenticationPrincipal User user,
+
+            @Parameter(description = "자주 착용한 아이템 개수", example = "10")
+            @RequestParam(defaultValue = "10") int frequentLimit,
+
+            @Parameter(description = "최근 착용하지 않은 아이템 미리보기 개수", example = "3")
+            @RequestParam(defaultValue = "3") int inactivePreviewLimit,
+
+            @Parameter(description = "미착용 기준 일수", example = "30")
+            @RequestParam(defaultValue = "30") int inactiveDays
+    );
+}

--- a/src/main/java/com/nova/yeobaek/domain/stats/dto/response/StatsResponseDTO.java
+++ b/src/main/java/com/nova/yeobaek/domain/stats/dto/response/StatsResponseDTO.java
@@ -1,0 +1,23 @@
+package com.nova.yeobaek.domain.stats.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class StatsResponseDTO {
+
+    /** 아이템 카드 */
+    public record ItemUsageCard(
+            Long itemId,
+            String brandName,
+            String imageUrl,
+            int useCount,
+            LocalDate lastUsedDate
+    ) {}
+
+    /** 화면 요약 응답 */
+    public record ItemsSummaryResponse(
+            List<ItemUsageCard> frequentItems,
+            List<ItemUsageCard> inactiveItemsPreview,
+            int inactiveItemsExtraCount
+    ) {}
+}

--- a/src/main/java/com/nova/yeobaek/domain/stats/service/StatsService.java
+++ b/src/main/java/com/nova/yeobaek/domain/stats/service/StatsService.java
@@ -1,0 +1,114 @@
+package com.nova.yeobaek.domain.stats.service;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nova.yeobaek.domain.item.domain.Item;
+import com.nova.yeobaek.domain.item.repository.ItemRepository;
+import com.nova.yeobaek.domain.stats.dto.response.StatsResponseDTO;
+import com.nova.yeobaek.domain.user.domain.mapping.ItemUsage;
+import com.nova.yeobaek.domain.user.repository.itemUsage.ItemUsageRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StatsService {
+
+    private final ItemRepository itemRepository;
+    private final ItemUsageRepository itemUsageRepository;
+
+    public StatsResponseDTO.ItemsSummaryResponse getItemsSummary(
+            Long userId,
+            int frequentLimit,
+            int inactivePreviewLimit,
+            int inactiveDays
+    ) {
+        // 1) 유저 보유 아이템 전체
+        List<Item> items = itemRepository.findAllByUser_Id(userId);
+
+        // 2) 아이템 사용 정보 (useCount DESC)
+        List<ItemUsage> usages = itemUsageRepository.findAllByUser_IdOrderByUseCountDesc(userId);
+
+        // itemId -> usage 맵
+        Map<Long, ItemUsage> usageMap = usages.stream()
+                .collect(Collectors.toMap(
+                        u -> u.getItem().getId(),
+                        u -> u,
+                        (a, b) -> a
+                ));
+
+        // 3) 자주 착용한 아이템 (전체 items 기준으로 일관되게)
+        List<StatsResponseDTO.ItemUsageCard> frequentItems = items.stream()
+                .map(item -> toCard(item, usageMap.get(item.getId())))
+                .filter(c -> c.useCount() > 0)
+                .sorted(Comparator.comparingInt(StatsResponseDTO.ItemUsageCard::useCount).reversed())
+                .limit(frequentLimit)
+                .toList();
+
+        // frequent에 포함된 itemId Set → inactive에서 제외
+        Set<Long> frequentItemIds = frequentItems.stream()
+                .map(StatsResponseDTO.ItemUsageCard::itemId)
+                .collect(Collectors.toSet());
+
+        // 4) 최근 착용하지 않은 아이템
+        LocalDate cutoff = LocalDate.now().minusDays(inactiveDays);
+
+        List<StatsResponseDTO.ItemUsageCard> inactiveAll = items.stream()
+                .map(item -> toCard(item, usageMap.get(item.getId())))
+                .filter(card -> !frequentItemIds.contains(card.itemId()))
+                .filter(card ->
+                        card.lastUsedDate() == null ||
+                                card.lastUsedDate().isBefore(cutoff) // cutoff 당일은 inactive 아님
+                )
+                .sorted(Comparator
+                        .comparing((StatsResponseDTO.ItemUsageCard c) -> c.lastUsedDate() != null)
+                        .thenComparing(
+                                StatsResponseDTO.ItemUsageCard::lastUsedDate,
+                                Comparator.nullsFirst(Comparator.naturalOrder())
+                        )
+                )
+                .toList();
+
+        List<StatsResponseDTO.ItemUsageCard> inactivePreview = inactiveAll.stream()
+                .limit(inactivePreviewLimit)
+                .toList();
+
+        int extraCount = Math.max(0, inactiveAll.size() - inactivePreview.size());
+
+        return new StatsResponseDTO.ItemsSummaryResponse(
+                frequentItems,
+                inactivePreview,
+                extraCount
+        );
+    }
+
+    private StatsResponseDTO.ItemUsageCard toCard(ItemUsage usage) {
+        Item item = usage.getItem();
+        return new StatsResponseDTO.ItemUsageCard(
+                item.getId(),
+                item.getBrand() != null ? item.getBrand().getName() : null,
+                item.getImageUrl(),
+                usage.getUseCount(),
+                usage.getLastUsedDate()
+        );
+    }
+
+    private StatsResponseDTO.ItemUsageCard toCard(Item item, ItemUsage usage) {
+        return new StatsResponseDTO.ItemUsageCard(
+                item.getId(),
+                item.getBrand() != null ? item.getBrand().getName() : null,
+                item.getImageUrl(),
+                usage == null ? 0 : usage.getUseCount(),
+                usage == null ? null : usage.getLastUsedDate()
+        );
+    }
+}


### PR DESCRIPTION
## 개요
- closed #33

아이템 착용 통계 조회를 위한 Stats API를 구현했습니다.  
자주 착용한 아이템(frequent)과 최근 미착용 아이템(inactive)을 명확히 분리하여 조회할 수 있도록 로직을 추가했습니다.

inactive 아이템은 최근 N일 미착용 기준으로 판단하며,  
미리보기(preview) 개수 제한과 그 외 개수(extraCount)를 함께 제공하도록 설계했습니다.

사전에 db에 테스트용 아이템값들을 입력해놓고 ootd데이터를 생성합니다.
<img width="1337" height="486" alt="image" src="https://github.com/user-attachments/assets/bdf56010-0d9c-47a5-8c6b-ee97cf1f7b7f" />
그후 테스트용 날짜에 ootd를 등록합니다 
<img width="1336" height="647" alt="image" src="https://github.com/user-attachments/assets/42704180-ce71-461f-86eb-aa32f6aa03c9" />
자주착용한 아이템갯수, 최근착용하지 않은 아이템 미리보기 갯수, 미착용 기준일수를 설정하고
<img width="1315" height="599" alt="image" src="https://github.com/user-attachments/assets/1132ffa0-8718-4695-992d-62396427e171" />
<img width="1320" height="573" alt="image" src="https://github.com/user-attachments/assets/5d95d75f-a505-4cc1-8e5e-1f569a24fdab" />
<img width="1208" height="370" alt="image" src="https://github.com/user-attachments/assets/58b1ce81-408e-479b-862b-f12d1f9d5bc8" />
<img width="1209" height="193" alt="image" src="https://github.com/user-attachments/assets/39b6e3d9-6867-4d49-a6f8-8cf7c825c778" />
이런식으로 자주착용한아이템과 안한 아이템을 확인할수있습니다
---

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(Swagger를 통한 API 동작 확인)

---

📣 **To Reviewers**
- frequent 아이템과 inactive 아이템을 배타적으로 분리하는 로직이 핵심입니다.
- inactiveItemsExtraCount는 previewLimit으로 인해 화면에 노출되지 않은 개수입니다.
- inactive 기준은 최근 N일 미착용만 사용합니다(useCount 낮음은 고려하지 않음).

- Reviewers : Backend 팀
- Labels : feature, stats
