### PR TITLE
[Fix] #28 OOTD 수정 및 삭제 시, 아이템 사용 횟수 업데이트 & 캘린더 기록 업데이트 로직

### DIFF
--- a/src/main/java/com/nova/yeobaek/domain/calendar/repository/CalendarRepository.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/repository/CalendarRepository.java
@@ -15,6 +15,10 @@ public interface CalendarRepository extends JpaRepository<Calendar, Long> {
     //  월 캘린더 조회(기간 내 기록 있는 날짜들만)
     List<Calendar> findAllByUserIdAndDateBetween(Long userId, LocalDate start, LocalDate end);
 
+    /** OOTD 삭제 연동용
+     특정 사용자의 특정 OOTD가 기록된 모든 캘린더 엔트리 조회 */
+    List<Calendar> findAllByUser_IdAndOotd_Id(Long userId, Long ootdId);
+
     // (선택) 월 로직엔 필수는 아니지만, 삭제/생성 로직에 쓰면 편함
     boolean existsByUserIdAndDate(Long userId, LocalDate date);
     void deleteByUserIdAndDate(Long userId, LocalDate date);

--- a/src/main/java/com/nova/yeobaek/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/nova/yeobaek/domain/calendar/service/CalendarService.java
@@ -380,4 +380,54 @@ public class CalendarService {
         if (hasOotd) return c.getOotdImageUrl();
         return null;
     }
+
+    /** OOTD 삭제 시 사용 */
+    // 특정 OOTD가 기록된 모든 캘린더 엔트리를 삭제
+    //캘린더 엔트리 1건 삭제 = 아이템사용횟수 1회 감소
+    // ItemUsageService는 Calendar 도메인에서만 호출
+    // OOTDService에서는 아이템사용횟수를 만지지 않음
+     @Transactional
+    public void deleteAllEntriesByOotd(User user, Long ootdId) {
+        if (ootdId == null) return;
+
+        List<Calendar> calendars =
+                calendarRepository.findAllByUser_IdAndOotd_Id(user.getId(), ootdId);
+
+        for (Calendar calendar : calendars) {
+            // 캘린더 1건 삭제 = 아이템 사용 횟수 1회 차감
+            itemUsageService.decreaseByOotd(user, ootdId);
+            calendarRepository.delete(calendar);
+        }
+    }
+
+    /** OOTD 수정 시 사용 */
+    @Transactional
+    public void updateItemUsageByOotdChange(
+            User user,
+            Long ootdId,
+            List<Long> removedItemIds,
+            List<Long> addedItemIds
+    ) {
+        if ((removedItemIds == null || removedItemIds.isEmpty())
+                && (addedItemIds == null || addedItemIds.isEmpty())) {
+            return;
+        }
+
+        // 이 OOTD가 캘린더에 등록된 모든 날짜 수
+        List<Calendar> calendars =
+                calendarRepository.findAllByUser_IdAndOotd_Id(user.getId(), ootdId);
+
+        int usedCount = calendars.size();
+        if (usedCount == 0) return;
+
+        // 제거된 아이템 → 사용 횟수 감소
+        for (Long itemId : removedItemIds) {
+            itemUsageService.decrease(user, itemId, usedCount);
+        }
+
+        // 추가된 아이템 → 사용 횟수 증가
+        for (Long itemId : addedItemIds) {
+            itemUsageService.increase(user, itemId, usedCount);
+        }
+    }
 }

--- a/src/main/java/com/nova/yeobaek/domain/ootd/domain/OOTD.java
+++ b/src/main/java/com/nova/yeobaek/domain/ootd/domain/OOTD.java
@@ -120,6 +120,11 @@ public class OOTD extends BaseEntity {
         this.imageBackgroundColor = backgroundColor;
     }
 
+	//OOTD수정시 기존 매핑 삭제
+	public void clearOotdItems() {
+		this.ootdItemList.clear();
+	}
+
     //아이템 변경 횟수 증가
     public void increaseChangeItemCount() {
         this.changeItemCount++;

--- a/src/main/java/com/nova/yeobaek/domain/ootd/service/OOTDService.java
+++ b/src/main/java/com/nova/yeobaek/domain/ootd/service/OOTDService.java
@@ -34,11 +34,14 @@ import com.nova.yeobaek.domain.ootd.dto.response.OOTDDetailResponse;
 import com.nova.yeobaek.domain.ootd.dto.response.OOTDItemDetailResponse;
 import com.nova.yeobaek.domain.ootd.domain.enums.OOTDStatus;
 
+import com.nova.yeobaek.domain.calendar.service.CalendarService;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class OOTDService {
 
+    private final CalendarService calendarService;
     private final OOTDRepository ootdRepository;
     private final OOTDItemRepository ootdItemRepository;
     private final StyleRepository styleRepository;
@@ -190,25 +193,46 @@ public class OOTDService {
             return;
         }
 
-        List<OOTDItem> beforeItems = ootd.getOotdItemList();
+        // 1. before 아이템 ID 목록
+        List<Long> beforeItemIds = ootd.getOotdItemList().stream()
+                .map(oi -> oi.getItem().getId())
+                .toList();
 
-        ootdItemRepository.deleteAllByOotd_Id(ootd.getId());
-
-        List<Long> itemIds = requestDTO.items().stream()
+        // 2. after 아이템 ID 목록
+        List<Long> afterItemIds = requestDTO.items().stream()
                 .map(OOTDRequestDTO.Item::fashionItemId)
                 .toList();
 
-        validateDuplicatedItemIds(itemIds);
-        Map<Long, Item> itemMap = loadItemsOrThrow(itemIds);
+        validateDuplicatedItemIds(afterItemIds);
 
+        // 3. diff 계산
+        List<Long> removedItemIds = beforeItemIds.stream()
+                .filter(id -> !afterItemIds.contains(id))
+                .toList();
+
+        List<Long> addedItemIds = afterItemIds.stream()
+                .filter(id -> !beforeItemIds.contains(id))
+                .toList();
+
+        // 4. 기존 매핑 삭제
+        ootdItemRepository.deleteAllByOotd_Id(ootd.getId());
+        ootd.clearOotdItems();
+
+        // 5. 새 매핑 저장
+        Map<Long, Item> itemMap = loadItemsOrThrow(afterItemIds);
         List<OOTDItem> newItems =
                 OOTDConverter.toOOTDItems(requestDTO.items(), ootd, itemMap);
-
         ootdItemRepository.saveAll(newItems);
+
         ootd.increaseChangeItemCount();
 
-        // TODO(#calendar): 해당 OOTD가 기록된 캘린더 엔트리들의 ootdImageUrl 최신화
-        // TODO(#item): 캘린더 기록 수 기준으로 아이템 착용 횟수 diff 반영
+        // 6. 캘린더 기준 아이템 사용횟수 diff 반영
+        calendarService.updateItemUsageByOotdChange(
+                ootd.getUser(),
+                ootd.getId(),
+                removedItemIds,
+                addedItemIds
+        );
     }
 
     /** OOTD 삭제 (하드 딜리트) */
@@ -219,15 +243,13 @@ public class OOTDService {
                 .filter(o -> o.getUser().getId().equals(user.getId()))
                 .orElseThrow(() -> new OOTDException(OOTDErrorStatus.OOTD_NOT_FOUND));
 
-        // 1. OOTD에 연결된 아이템 매핑 삭제
-        ootdItemRepository.deleteAllByOotd_Id(ootd.getId());
+        // 캘린더 도메인에 위임 (아이템 사용 횟수 감소도 여기서 처리)
+        calendarService.deleteAllEntriesByOotd(user, ootdId);
 
-        // 2. TODO: 캘린더 파트 머지 후 연동
-        // TODO(#calendar): 해당 OOTD가 기록된 모든 캘린더 엔트리 삭제
-        // TODO(#calendar): 캘린더 삭제에 따른 아이템 사용 횟수 차감
-        // 아직 캘린더 도메인이 푸쉬되지 않아서 제가 건드릴 수 없어서 일단 투두로 뒀습니다!!
+        // OOTD-Item 매핑 삭제
+        ootdItemRepository.deleteAllByOotd_Id(ootdId);
 
-        // 3. OOTD 하드딜리트
+        // OOTD 하드 딜리트
         ootdRepository.delete(ootd);
     }
 

--- a/src/main/java/com/nova/yeobaek/domain/user/domain/mapping/ItemUsage.java
+++ b/src/main/java/com/nova/yeobaek/domain/user/domain/mapping/ItemUsage.java
@@ -69,4 +69,22 @@ public class ItemUsage extends BaseEntity {
 	public void decrease() {
 		this.useCount = Math.max(0, this.useCount - 1);
 	}
+
+    /**
+     * OOTD 수정 diff 반영용
+     * - 특정 아이템 사용 횟수를 N회 증가
+     */
+    public void increase(int count) {
+        if (count <= 0) return;
+        this.useCount += count;
+    }
+
+    /**
+     * OOTD 수정 diff 반영용
+     * - 특정 아이템 사용 횟수를 N회 감소 (0 미만 방지)
+     */
+    public void decrease(int count) {
+        if (count <= 0) return;
+        this.useCount = Math.max(0, this.useCount - count);
+    }
 }

--- a/src/main/java/com/nova/yeobaek/domain/user/service/ItemUsageService.java
+++ b/src/main/java/com/nova/yeobaek/domain/user/service/ItemUsageService.java
@@ -13,6 +13,7 @@ import com.nova.yeobaek.domain.ootd.repository.ootdItem.OOTDItemRepository;
 import com.nova.yeobaek.domain.user.domain.User;
 import com.nova.yeobaek.domain.user.domain.mapping.ItemUsage;
 import com.nova.yeobaek.domain.user.repository.itemUsage.ItemUsageRepository;
+import com.nova.yeobaek.domain.item.repository.ItemRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,6 +23,7 @@ public class ItemUsageService {
 
     private final ItemUsageRepository itemUsageRepository;
     private final OOTDItemRepository ootdItemRepository;
+    private final ItemRepository itemRepository;
 
     @Transactional
     public void increaseByOotd(User user, Long ootdId, LocalDate date) {
@@ -32,7 +34,7 @@ public class ItemUsageService {
         for (OOTDItem oi : ootdItems) {
             Long itemId = oi.getItem().getId();
 
-            ItemUsage usage = getOrCreateUsage(user, oi.getItem(), itemId);
+            ItemUsage usage = getOrCreateUsage(user, oi.getItem());
             usage.increase(date);
         }
     }
@@ -55,9 +57,8 @@ public class ItemUsageService {
     public void increase(User user, Long itemId, int count) {
         if (count <= 0) return;
 
-        ItemUsage usage = itemUsageRepository
-                .findByUser_IdAndItem_Id(user.getId(), itemId)
-                .orElseThrow(); // 캘린더에 있었다면 반드시 존재
+        Item itemRef = itemRepository.getReferenceById(itemId);
+        ItemUsage usage = getOrCreateUsage(user, itemRef);
 
         usage.increase(count);
     }
@@ -75,7 +76,9 @@ public class ItemUsageService {
      * - find 후 없으면 save 시도
      * - uk_user_item 유니크 충돌 발생 시(다른 트랜잭션이 먼저 생성) 재조회하여 반환
      */
-    private ItemUsage getOrCreateUsage(User user, Item item, Long itemId) {
+    private ItemUsage getOrCreateUsage(User user, Item item) {
+
+        Long itemId = item.getId();
 
         return itemUsageRepository.findByUser_IdAndItem_Id(user.getId(), itemId)
                 .orElseGet(() -> {
@@ -88,7 +91,7 @@ public class ItemUsageService {
                                         .build()
                         );
                     } catch (DataIntegrityViolationException e) {
-                        // 동시 생성 레이스로 유니크 충돌 → 기존 row 재조회 후 사용
+                        // 동시 생성 레이스 → 기존 row 재조회
                         return itemUsageRepository.findByUser_IdAndItem_Id(user.getId(), itemId)
                                 .orElseThrow(() -> e);
                     }

--- a/src/main/java/com/nova/yeobaek/domain/user/service/ItemUsageService.java
+++ b/src/main/java/com/nova/yeobaek/domain/user/service/ItemUsageService.java
@@ -51,6 +51,25 @@ public class ItemUsageService {
         }
     }
 
+    @Transactional
+    public void increase(User user, Long itemId, int count) {
+        if (count <= 0) return;
+
+        ItemUsage usage = itemUsageRepository
+                .findByUser_IdAndItem_Id(user.getId(), itemId)
+                .orElseThrow(); // 캘린더에 있었다면 반드시 존재
+
+        usage.increase(count);
+    }
+
+    @Transactional
+    public void decrease(User user, Long itemId, int count) {
+        if (count <= 0) return;
+
+        itemUsageRepository.findByUser_IdAndItem_Id(user.getId(), itemId)
+                .ifPresent(usage -> usage.decrease(count));
+    }
+
     /**
      * ✅ 동시성 안전 get-or-create
      * - find 후 없으면 save 시도


### PR DESCRIPTION
## 개요
- closed #28

OOTD ↔ Calendar 연동 과정에서  
- OOTD 수정/삭제 시 아이템 착용 횟수(use_count)가 반영되도록 구현.
- OOTD 수정 시 아이템 구성 변경(diff)에 따라 추가/삭제된 아이템만 사용 횟수가 증감되도록 구성.
- OOTD 삭제 시에도 캘린더 기준으로 아이템 사용 기록이 비례해서 감소하도록 구현.
<img width="903" height="140" alt=" 아이템첫조회" src="https://github.com/user-attachments/assets/d1d3e6c9-9f31-4c63-975c-4e39c3937a6c" />
→  초기 아이템 사용 횟수를 조회

<img width="261" height="203" alt="1:23에기록" src="https://github.com/user-attachments/assets/00b0d961-f207-44d9-ba94-55de4c9fdaf4" />
<img width="452" height="272" alt="1:24에기록" src="https://github.com/user-attachments/assets/33c5210d-e244-4332-936b-b4b5af85f659" />
→  1/23과 1/24에 OOTD42를 추가(아이템13,14,15을 1개씩 포함한 OOTD)
<img width="897" height="156" alt="기록후조회" src="https://github.com/user-attachments/assets/7b82b36f-5848-4c31-9fee-884cb267b796" />
→  13,14,15 아이템의 사용횟수가 2회씩 증가
<img width="902" height="156" alt="14→16후조회" src="https://github.com/user-attachments/assets/2e6b74ad-f572-49bb-9d63-3354930d49b6" />
→  OOTD 42의 아이템14를 아이템16으로 변경 후 조회
<img width="908" height="167" alt="삭제후조회" src="https://github.com/user-attachments/assets/11296751-5a8a-457e-949a-f804811b22e6" />
→  OOTD 42를 삭제 조회


<!-- Resolves: #28 -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (Swagger / DB 쿼리 기반 검증)

📣 **To Reviewers**
---
- OOTD 수정 시 아이템 전체 삭제 후 재삽입 구조로 인해 발생하던 중복 매핑 및 아이템 사용 횟수 누적 이슈를 해결했습니다.
- 아이템 사용 횟수 변경 로직은 CalendarService에 책임을 뒀습니다.

- Reviewers : @Jinho-5 
- Labels : feat, bugfix, calendar, ootd